### PR TITLE
New serverless snippet - Lambda cold starts count and init duration

### DIFF
--- a/cloudwatch-insight-lambda-cold-starts-count-and-duration/README.md
+++ b/cloudwatch-insight-lambda-cold-starts-count-and-duration/README.md
@@ -1,0 +1,26 @@
+# Running the CloudWatch Logs Insight Snippet
+
+Returns the number of Lambda cold starts and init duration.
+
+Learn more about this snippet at Serverless Land Snippets: https://serverlessland.com/snippets/cloudwatch-insight-lambda-cold-starts-count-and-duration
+
+Important: this application could use various AWS services and there are costs associated with these services after the Free Tier usage - please see the [AWS Pricing page](https://aws.amazon.com/pricing/) for details. You are responsible for any AWS costs incurred. No warranty is implied in this example.
+
+
+## How it works
+
+Uses CloudWatch Insights to query a given log group and returns the number of Lambda cold starts and the init duration bucketed by 5 minutes.
+
+[Follow the instructions on the snippet page](https://serverlessland.com/snippets/cloudwatch-insight-lambda-cold-start-invocations) to run in your AWS account.
+
+## Cleanup
+
+No clean up required.
+
+---
+
+Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+SPDX-License-Identifier: MIT-0
+
+

--- a/cloudwatch-insight-lambda-cold-starts-count-and-duration/snippet-data.json
+++ b/cloudwatch-insight-lambda-cold-starts-count-and-duration/snippet-data.json
@@ -1,0 +1,31 @@
+{
+  "title": "Lambda cold starts count and init duration",
+  "description": "Cloudwatch Log Insight snippet that returns the number of cold starts and init duration.",
+  "type": "CloudWatch Logs Insights",
+  "services": ["lambda"],
+  "introBox": {
+    "headline": "How it works",
+    "text": ["Uses CloudWatch Insights to query a given log group and returns the number of Lambda cold starts and the init duration bucketed by 5 minutes."]
+  },
+  "gitHub": {
+    "template": {
+      "repoURL": "https://github.com/aws-samples/serverless-snippets/tree/main/cloudwatch-insight-lambda-cold-starts-count-and-duration"
+    }
+  },
+  "snippets": [
+    {
+      "snippetPath": "snippet.txt",
+      "language": "css"
+    }
+  ],
+  "authors": [
+    {
+      "headline": "Presented by Maciej Radzikowski",
+      "name": "Maciej Radzikowski",
+      "image": "https://s.gravatar.com/avatar/6e0a003112cf85b065576cdde29e0956?s=200",
+      "bio": "Software Developer and Architect, doing serverless on AWS and blogging about it.",
+      "linkedin": "mradzikowski",
+      "twitter": "radzikowski_m"
+    }
+  ]
+}

--- a/cloudwatch-insight-lambda-cold-starts-count-and-duration/snippet.txt
+++ b/cloudwatch-insight-lambda-cold-starts-count-and-duration/snippet.txt
@@ -1,0 +1,4 @@
+filter @type="REPORT"
+| filter @message like /(?i)(Init Duration)/
+| parse @message /^REPORT.*Init Duration: (?<initDuration>.*) ms.*/
+| stats count() as coldStarts, avg(initDuration), min(initDuration), max(initDuration) by bin(5m)


### PR DESCRIPTION
*Description of changes:*

Added new CloudWatch Logs Insights snippet to get Lambda cold starts count and their init duration.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
