### PR TITLE
Use the Provided Field for Snippets Involving Init Duration

### DIFF
--- a/cloudwatch-insight-lambda-cold-start-invocations/snippet-data.json
+++ b/cloudwatch-insight-lambda-cold-start-invocations/snippet-data.json
@@ -26,6 +26,13 @@
       "bio": "Serverless Developer Advocate at AWS",
       "linkedin": "",
       "twitter": "boyney123"
+    },
+    {
+      "headline": "Contributed to by Christopher Osborn",
+      "name": "Christopher Osborn",
+      "image": "http://s.gravatar.com/avatar/7e346e10164f82dbc6dc366d8733200c?s=256",
+      "bio": "Software Engineer with a focus on serverless technologies.",
+      "twitter": "chrisoverzero"
     }
   ]
 }

--- a/cloudwatch-insight-lambda-cold-start-invocations/snippet.txt
+++ b/cloudwatch-insight-lambda-cold-start-invocations/snippet.txt
@@ -1,5 +1,4 @@
-	
 filter @type = "REPORT"
-| stats sum(strcontains(@message, "Init Duration"))/count(*) * 100 as
+| stats sum(ispresent(@initDuration))/count() * 100 as
   coldStartPct, avg(@duration)
   by bin(5m)

--- a/cloudwatch-insight-lambda-cold-starts-count-and-duration/snippet-data.json
+++ b/cloudwatch-insight-lambda-cold-starts-count-and-duration/snippet-data.json
@@ -26,6 +26,13 @@
       "bio": "Software Developer and Architect, doing serverless on AWS and blogging about it.",
       "linkedin": "mradzikowski",
       "twitter": "radzikowski_m"
+    },
+    {
+      "headline": "Contributed to by Christopher Osborn",
+      "name": "Christopher Osborn",
+      "image": "http://s.gravatar.com/avatar/7e346e10164f82dbc6dc366d8733200c?s=256",
+      "bio": "Software Engineer with a focus on serverless technologies.",
+      "twitter": "chrisoverzero"
     }
   ]
 }

--- a/cloudwatch-insight-lambda-cold-starts-count-and-duration/snippet.txt
+++ b/cloudwatch-insight-lambda-cold-starts-count-and-duration/snippet.txt
@@ -1,4 +1,2 @@
-filter @type="REPORT"
-| filter @message like /(?i)(Init Duration)/
-| parse @message /^REPORT.*Init Duration: (?<initDuration>.*) ms.*/
-| stats count() as coldStarts, avg(initDuration), min(initDuration), max(initDuration) by bin(5m)
+filter @type="REPORT" and ispresent(@initDuration)
+| stats count() as coldStarts, avg(@initDuration), min(@initDuration), max(@initDuration) by bin(5m)

--- a/cloudwatch-insight-lambda-total-innvocations-vs-coldstarts/snippet-data.json
+++ b/cloudwatch-insight-lambda-total-innvocations-vs-coldstarts/snippet-data.json
@@ -26,6 +26,13 @@
       "bio": "Serverless Developer Advocate at AWS",
       "linkedin": "",
       "twitter": "boyney123"
+    },
+    {
+      "headline": "Contributed to by Christopher Osborn",
+      "name": "Christopher Osborn",
+      "image": "http://s.gravatar.com/avatar/7e346e10164f82dbc6dc366d8733200c?s=256",
+      "bio": "Software Engineer with a focus on serverless technologies.",
+      "twitter": "chrisoverzero"
     }
   ]
 }

--- a/cloudwatch-insight-lambda-total-innvocations-vs-coldstarts/snippet.txt
+++ b/cloudwatch-insight-lambda-total-innvocations-vs-coldstarts/snippet.txt
@@ -1,3 +1,2 @@
 filter @type = "REPORT" |
-parse @message /Init Duration: (?<init>\S+)/ |
-stats count() as TotalInvocations, count(init) as TotalColdStarts
+stats count() as TotalInvocations, count(@initDuration) as TotalColdStarts


### PR DESCRIPTION
Rather than using parsing for cold start detection and statistics, use
the provided field `@initDuration`. This simplifies the snippets to my
eye, at least.

*Issue #, if available:* N/A

*Description of changes:*
Where snippets used regexes for detection of cold start REPORTs, they now detect the presence of the `@initDuration` field, which is pre-provided by CWLI. Where snippets used `parse` to extract the value of the cold start duration, they now use the value of `@initDuration` in the same way.

I changed one `filter | filter` to an `and` because it seemed reasonable, but I recognize that it's a style choice. Would undo, if asked.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
