### PR TITLE
Created two AWS CLI snippets

### DIFF
--- a/aws-cli-get-cloudformation-stacks/snippet-data.json
+++ b/aws-cli-get-cloudformation-stacks/snippet-data.json
@@ -1,0 +1,33 @@
+{
+  "title": "List CloudFormation Stacks",
+  "description": "An AWS CLI command to list all CloudFormation Stacks and a query to show how to only show StackId and StackName",
+  "type": "AWS CLI",
+  "services": ["CloudFormation"],
+  "languages": ["aws cli"],
+  "tags": ["debugging"],
+  "introBox": {
+    "headline": "How it works",
+    "text": ["An AWS CLI command that retrieves all the stacks from CloudFormation and outputs them. The optional query parameter limits the output of the command so that only the StackIs and the StackName are returned."]
+  },
+  "gitHub": {
+    "template": {
+      "repoURL": "https://github.com/aws-samples/serverless-snippets/tree/main/aws-cli-get-cloudformation-stacks"
+    }
+  },
+  "snippets": [
+    {
+      "snippetPath": "snippet.txt",
+      "language": "aws cli"
+    }
+  ],
+  "authors": [
+    {
+      "headline": "Hopefully something useful from Paul Johnston",
+      "name": "Paul Johnston",
+      "image": "https://pbs.twimg.com/profile_images/1489994130004533259/gz6LI1oW_400x400.jpg",
+      "bio": "CTO, Consultant, Interim and Strategist (and ex-Serverless Developer Advocate at AWS)",
+      "linkedin": "https://www.linkedin.com/in/padajo/",
+      "twitter": "PaulDJohnston"
+    }
+  ]
+}

--- a/aws-cli-get-cloudformation-stacks/snippet.txt
+++ b/aws-cli-get-cloudformation-stacks/snippet.txt
@@ -1,0 +1,3 @@
+aws cloudformation list-stacks
+or
+aws cloudformation list-stacks  --query "StackSummaries[*].{StackId: StackId, StackName: StackName}"

--- a/aws-cli-get-functions-in-cloudformation-stack/snippet-data.json
+++ b/aws-cli-get-functions-in-cloudformation-stack/snippet-data.json
@@ -1,0 +1,33 @@
+{
+  "title": "Get Lambda Functions in a CloudFormation Stack",
+  "description": "An AWS CLI command to retrieve all AWS Lambda function resources in a named CloudFormation Stack",
+  "type": "AWS CLI",
+  "services": ["lambda", "CloudFormation"],
+  "languages": ["aws cli"],
+  "tags": ["debugging"],
+  "introBox": {
+    "headline": "How it works",
+    "text": ["AWS CLI command that retrieves all the resources in a CloudFormation stack and queries the returned data for ResourceType of 'AWS::Lambda::Function'"]
+  },
+  "gitHub": {
+    "template": {
+      "repoURL": "https://github.com/aws-samples/serverless-snippets/tree/main/aws-cli-get-functions-in-cloudformation-stack"
+    }
+  },
+  "snippets": [
+    {
+      "snippetPath": "snippet.txt",
+      "language": "aws cli"
+    }
+  ],
+  "authors": [
+    {
+      "headline": "Hopefully something useful from Paul Johnston",
+      "name": "Paul Johnston",
+      "image": "https://pbs.twimg.com/profile_images/1489994130004533259/gz6LI1oW_400x400.jpg",
+      "bio": "CTO, Consultant, Interim and Strategist (and ex-Serverless Developer Advocate at AWS)",
+      "linkedin": "https://www.linkedin.com/in/padajo/",
+      "twitter": "PaulDJohnston"
+    }
+  ]
+}

--- a/aws-cli-get-functions-in-cloudformation-stack/snippet.txt
+++ b/aws-cli-get-functions-in-cloudformation-stack/snippet.txt
@@ -1,0 +1,1 @@
+aws cloudformation list-stack-resources --stack-name (stack id) --query "StackResourceSummaries[?ResourceType=='AWS::Lambda::Function'].{LogicalResourceId: LogicalResourceId, PhysicalResourceId: PhysicalResourceId, LastUpdate: LastUpdatedTimestamp}"


### PR DESCRIPTION
Created AWS CLI snippets for listing CloudFormation stacks in a region and for retrieving all the AWS Lambda functions in a CloudFormation stack.

These are very useful for when you want to find details of the correct function in the AWS CLI quickly.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
