### PR TITLE
Replace getObject by headObject

### DIFF
--- a/integration-s3-to-lambda/example.js
+++ b/integration-s3-to-lambda/example.js
@@ -11,7 +11,7 @@ exports.handler = async (event, context) => {
         Key: key,
     }; 
     try {
-        const { ContentType } = await s3.getObject(params).promise();
+        const { ContentType } = await s3.headObject(params).promise();
         console.log('CONTENT TYPE:', ContentType);
         return ContentType;
     } catch (err) {


### PR DESCRIPTION
The **headObjects** method tends to be faster if one only wants metadata and not the real object's content.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution under the terms of your choice.
