### PR TITLE
adding new cloudwatch log group tail command

### DIFF
--- a/aws-cli-tail-clogwatch-loggroup/example.txt
+++ b/aws-cli-tail-clogwatch-loggroup/example.txt
@@ -1,0 +1,36 @@
+2022-10-05T08:32:51+00:00 f525e7be-c42d-3f0d-a7c4-6a51d01da714
+{
+    "version": "0",
+    "id": "daf8f653-560e-df19-c0d7-441cb55c414a",
+    "detail-type": "UserCreated",
+    "source": "com.mycompany.myapp",
+    "account": "123456789123",
+    "time": "2022-10-05T08:32:51Z",
+    "region": "us-west-2",
+    "resources": [
+        "resource1",
+        "resource2"
+    ],
+    "detail": {
+        "key1": "value1",
+        "key2": "value2"
+    }
+}
+2022-10-05T08:33:05+00:00 c996a3cc-dd68-3aef-9fbb-6a2c7f8e4472
+{
+    "version": "0",
+    "id": "3b256c05-8879-e7f5-94be-ce3bc7af68f4",
+    "detail-type": "UserCreated",
+    "source": "com.mycompany.myapp",
+    "account": "123456789123",
+    "time": "2022-10-05T08:33:05Z",
+    "region": "us-west-2",
+    "resources": [
+        "resource1",
+        "resource2"
+    ],
+    "detail": {
+        "key1": "value1",
+        "key2": "value2"
+    }
+}

--- a/aws-cli-tail-clogwatch-loggroup/snippet-data.json
+++ b/aws-cli-tail-clogwatch-loggroup/snippet-data.json
@@ -1,0 +1,42 @@
+{
+  "title": "Tail CloudWatch log group",
+  "description": "An AWS CLI command to tail a CloudWatch log group",
+  "type": "AWS CLI",
+  "services": [""],
+  "languages": ["bash"],
+  "tags": ["debugging"],
+  "introBox": {
+    "headline": "How it works",
+    "text": [
+      "An AWS CLI command that tails a CloudWatch log group. Use to help debugging and get live logs into your terminal."
+    ]
+  },
+  "gitHub": {
+    "template": {
+      "repoURL": "https://github.com/aws-samples/serverless-snippets/tree/main/aws-cli-tail-clogwatch-loggroup"
+    }
+  },
+  "snippets": [
+    {
+      "title": "Tail CloudWatch log group into your terminal",
+      "description": "Run the command inside your terminal to tail a log group and get real time updates. You will need AWS CLI v2.",
+      "code": "aws logs tail {LogGroupName} --follow --format json",
+      "language": "bash"
+    },
+    {
+      "title": "Example output of watching an Amazon EventBridge CloudWatch log group",
+      "snippetPath": "example.txt",
+      "language": "bash"
+    }
+  ],
+  "authors": [
+    {
+      "headline": "Presented by David Boyne",
+      "name": "David Boyne",
+      "image": "https://pbs.twimg.com/profile_images/1262283153563140096/DYRDqKg6_400x400.png",
+      "bio": "Serverless Developer Advocate at AWS",
+      "linkedin": "",
+      "twitter": "boyney123"
+    }
+  ]
+}


### PR DESCRIPTION
*Description of changes:*

Adding new command to help people tail a cloudwatch log group into their terminal. Inspired by https://twitter.com/donkersgood/status/1575184107692490752


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
