### PR TITLE
Adding snippet to list lambda edge functions

### DIFF
--- a/lambda-list-edge-functions/snippet-data.json
+++ b/lambda-list-edge-functions/snippet-data.json
@@ -1,6 +1,6 @@
 {
   "title": "lambda-list-edge-functions-from-region",
-  "description": "Using cli to list lambda@edge functions replicated from a particular region",
+  "description": "Using CLI to list Lambda@Edge functions replicated from a particular region",
   "type": "Integration",
   "services": ["lambda"],
   "tags": [],
@@ -8,17 +8,17 @@
   "introBox": {
     "headline": "How it works",
     "text": [
-      "[This aws cli will list only the Lambda@edge function replicated from the master region that is configured in cli]"
+      "[This AWS CLI command will list only the Lambda@Edge function replicated from the master region that is configured in cli]"
     ]
   },
   "gitHub": {
     "template": {
-      "repoURL": "https://github.com/aws-samples/serverless-snippets/tree/main/cloudwatch-insight-exception-per-hour"
+      "repoURL": "https://github.com/aws-samples/serverless-snippets/tree/main/lambda-edge-list-functions"
     }
   },
   "snippets": [
     {
-      "title": "List the lambda@edge functions",
+      "title": "List the Lambda@Edge functions",
       "snippetPath": "snippet.txt",
       "language": "aws cli"
     }
@@ -26,10 +26,10 @@
   "authors": [
     {
       "headline": "Presented by Surya Dulla",
-      "name": "Surya dulla",
-      "image": "https://www.linkedin.com/in/surya-tejaswi-dulla-54b0b188/",
+      "name": "Surya Dulla",
+      "image": "https://media.licdn.com/dms/image/C4E03AQGAY8pmzboeow/profile-displayphoto-shrink_200_200/0/1562613473789?e=1681344000&v=beta&t=fOrFY98O69OLXLz5vjTsA3UWISAwJ37MeN_As6EP3gU",
       "bio": "DevOps Engineer at AWS, Advocate for Cloud technology",
-      "linkedin": "https://www.linkedin.com/in/surya-tejaswi-dulla-54b0b188/",
+      "linkedin": "surya-tejaswi-dulla-54b0b188",
     }
   ]
 }

--- a/lambda-list-edge-functions/snippet-data.json
+++ b/lambda-list-edge-functions/snippet-data.json
@@ -1,0 +1,35 @@
+{
+  "title": "lambda-list-edge-functions-from-region",
+  "description": "Using cli to list lambda@edge functions replicated from a particular region",
+  "type": "Integration",
+  "services": ["lambda"],
+  "tags": [],
+  "languages": ["aws cli"],
+  "introBox": {
+    "headline": "How it works",
+    "text": [
+      "[This aws cli will list only the Lambda@edge function replicated from the master region that is configured in cli]"
+    ]
+  },
+  "gitHub": {
+    "template": {
+      "repoURL": "https://github.com/aws-samples/serverless-snippets/tree/main/cloudwatch-insight-exception-per-hour"
+    }
+  },
+  "snippets": [
+    {
+      "title": "List the lambda@edge functions",
+      "snippetPath": "snippet.txt",
+      "language": "aws cli"
+    }
+  ],
+  "authors": [
+    {
+      "headline": "Presented by Surya Dulla",
+      "name": "Surya dulla",
+      "image": "https://www.linkedin.com/in/surya-tejaswi-dulla-54b0b188/",
+      "bio": "DevOps Engineer at AWS, Advocate for Cloud technology",
+      "linkedin": "https://www.linkedin.com/in/surya-tejaswi-dulla-54b0b188/",
+    }
+  ]
+}

--- a/lambda-list-edge-functions/snippet.txt
+++ b/lambda-list-edge-functions/snippet.txt
@@ -1,0 +1,1 @@
+aws lambda list-functions --master-region us-east-1 --function-version ALL


### PR DESCRIPTION
*Issue #27 :*

Adding a code snippet which can be used for listing the lambda@edge functions replicated from the master region that is configured in cli

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
