### PR TITLE
New serverless snippet - lambda-kafka-glue-schema-registry

### DIFF
--- a/lambda-function-kafka-consumer-glue-schema-registry/example.py
+++ b/lambda-function-kafka-consumer-glue-schema-registry/example.py
@@ -1,0 +1,79 @@
+import boto3
+import avro.io
+from uuid import UUID
+from datetime import datetime
+import base64
+import json
+import io
+
+print('Loading function')
+
+glue_client = boto3.client('glue')
+s3_client = boto3.client('s3')
+# memory cache for the inline schemas
+schema_map = {}
+
+def get_schema(schema_version_id):
+    print("loading schema for version: " + schema_version_id)
+
+    response = glue_client.get_schema_version(
+        SchemaVersionId=schema_version_id
+    )
+
+    return response['SchemaDefinition']
+
+def gsr_value_deserializer(raw_record):
+    # First two control bytes are put by Glue Schema Registry serializer.
+    # control_byte = raw_record[0]
+    # compression_byte = raw_record[1]
+
+    # version to deserialize each record.
+    version_bytes = raw_record[2:18]
+    schema_version = UUID(bytes=version_bytes)
+    schema_key = str(schema_version)
+    # print(schema_version)
+    
+    if schema_key in schema_map:
+        schema_inline = schema_map[schema_key]
+    else:
+        schema_inline = get_schema(schema_key)
+        schema_map[schema_key] = schema_inline
+
+    # raw data record begins after byte #18
+    raw_record = raw_record[18:]
+    schema = avro.schema.parse(schema_inline)
+    reader = avro.io.DatumReader(schema)
+
+    bytes_reader = io.BytesIO(raw_record)
+
+    decoder = avro.io.BinaryDecoder(bytes_reader)
+    msg = reader.read(decoder)
+    return msg
+
+
+def lambda_handler(event, context):
+    
+    # use time based file partitioning in S3
+    current_month = datetime.now().strftime('%m')
+    current_day = datetime.now().strftime('%d') 
+    current_year_full = datetime.now().strftime('%Y')
+    current_hour = datetime.now().strftime('%H')
+    current_minute = datetime.now().strftime('%M')
+    ct = datetime.now()
+
+    records = event['records']
+    messageAr = []
+    for key in records:
+        base64records = event['records'][key]
+        raw_records = [base64.b64decode(x["value"]) for x in base64records]
+        
+        for raw_record in raw_records:
+            record = gsr_value_deserializer(raw_record)
+            messageAr.append(record)
+            
+    s3_client.put_object(Body=json.dumps(messageAr), Bucket='<Your S3 Bucket>', Key='<your s3 prefix>/year=' + current_year_full + '/month=' + current_month + '/day=' + current_day + '/hour=' + current_hour + '/minute=' + current_minute + '/file-' + str(ct) + '.json')
+            
+    return {
+        'statusCode': 200,
+        'body': json.dumps('Finished processing!')
+    }

--- a/lambda-function-kafka-consumer-glue-schema-registry/snippet-data.json
+++ b/lambda-function-kafka-consumer-glue-schema-registry/snippet-data.json
@@ -1,0 +1,46 @@
+{
+  "title": "This function deserializes Kafka events using schema in AWS Glue Schema Registry",
+  "description": "AWS Lambda function that deserializes events in a Kafka topic using Avro schema in AWS Glue Schema Registry.",
+  "type": "Integration",
+  "services": ["lambda"],
+  "tags": [],
+  "languages": [],
+  "introBox": {
+    "headline": "How it works",
+    "text": [
+      "This code example shows how an AWS Lambda function can get invoked by Event Source Mapping to a Kafka topic. It downloads the corresponding schema from AWS Glue Schema Registry by looking up the schema version (by which the record has been serialized). The deserializes record is stored in JSON format in Amazon S3."
+    ]
+  },
+  "gitHub": {
+    "template": {
+      "repoURL": "https://github.com/aws-samples/serverless-snippets/tree/main/lambda-function-kafka-consumer-glue-schema-registry"
+    }
+  },
+  "snippets": [
+    {
+      "title": "Runtimes",
+      "codeTabs": [
+        {
+          "id": "Python",
+          "title": "Copy the code into your lambda function",
+          "description": "Follow the AWS Lambda instructions for packaging with dependencies, and uploading in .zip format.",
+          "snippets": [
+            {
+              "snippetPath": "example.py",
+              "language": "py"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "authors": [
+    {
+      "headline": "Presented by Ali Alemi",
+      "name": "Ali Alemi",
+      "image": "https://d2908q01vomqb2.cloudfront.net/b6692ea5df920cad691c20319a6fffd7a4a766b8/2022/09/27/BDB-2199-alialem.jpg",
+      "bio": "Ali Alemi is a Streaming Specialist Solutions Architect at AWS. Ali advises AWS customers with architectural best practices and helps them design real-time analytics data systems that are reliable, secure, efficient, and cost-effective. He works backward from customers’ use cases and designs data solutions to solve their business problems. Prior to joining AWS, Ali supported several public sector customers and AWS consulting partners in their application modernization journey and migration to the cloud.",
+      "linkedin": "ali-alemi-11869b53"
+    }
+  ]
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* This code example shows how an AWS Lambda function can get invoked by Event Source Mapping to a Kafka topic. It downloads the corresponding schema from AWS Glue Schema Registry by looking up the schema version (by which the record has been serialized). The deserializes record is stored in JSON format in Amazon S3.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
