### PR TITLE
CloudWatch Log Insights query snippets for EventBridge events.

### DIFF
--- a/cloudwatch-insight-eventbridge-event-by-detail-type-like/sample-data.json
+++ b/cloudwatch-insight-eventbridge-event-by-detail-type-like/sample-data.json
@@ -1,0 +1,35 @@
+{
+    "title": "Events that match a pattern for detail-type value",
+    "description": "Get the EventBridge events that match a pattern for detail-type value",
+    "type": "CloudWatch Logs Insights",
+    "services": [],
+    "tags": [
+      ""
+    ],
+    "introBox": {
+      "headline": "How it works",
+      "text": ["Cloudwatch Log Insight snippet that gets the EventBridge events that matches a pattern for detail-type value"]
+    },
+    "gitHub": {
+      "template": {
+        "repoURL": "https://github.com/aws-samples/serverless-snippets/tree/main/cloudwatch-insight-eventbridge-event-by-detail-type-like"
+      }
+    },
+    "snippets": [
+      {
+        "snippetPath": "snippet.txt",
+        "language": "css"
+      }
+    ],
+    "authors": [
+      {
+        "headline": "Presented by Rahul Sringeri",
+        "name": "Rahul Sringeri",
+        "image": "",
+        "bio": "Technical Account Manager at AWS for Strategic Accounts",
+        "linkedin": "",
+        "twitter": ""
+      }
+    ]
+  }
+  

--- a/cloudwatch-insight-eventbridge-event-by-detail-type-like/snippet.txt
+++ b/cloudwatch-insight-eventbridge-event-by-detail-type-like/snippet.txt
@@ -1,0 +1,3 @@
+fields @timestamp
+| filter `detail-type` like /sample-value/ # replace sample-value with actual value to be searched
+| sort @timestamp desc

--- a/cloudwatch-insight-eventbridge-event-count-by-source/snippet-data.json
+++ b/cloudwatch-insight-eventbridge-event-count-by-source/snippet-data.json
@@ -1,0 +1,35 @@
+{
+    "title": "Events grouped by source",
+    "description": "Get the number of EventBridge events by source",
+    "type": "CloudWatch Logs Insights",
+    "services": [],
+    "tags": [
+      ""
+    ],
+    "introBox": {
+      "headline": "How it works",
+      "text": ["Cloudwatch Log Insight snippet that counts the number of EventBridge events and groups by source"]
+    },
+    "gitHub": {
+      "template": {
+        "repoURL": "https://github.com/aws-samples/serverless-snippets/tree/main/cloudwatch-insight-eventbridge-event-count-by-source"
+      }
+    },
+    "snippets": [
+      {
+        "snippetPath": "snippet.txt",
+        "language": "css"
+      }
+    ],
+    "authors": [
+      {
+        "headline": "Presented by Rahul Sringeri",
+        "name": "Rahul Sringeri",
+        "image": "",
+        "bio": "Technical Account Manager at AWS for Strategic Accounts",
+        "linkedin": "",
+        "twitter": ""
+      }
+    ]
+  }
+  

--- a/cloudwatch-insight-eventbridge-event-count-by-source/snippet.txt
+++ b/cloudwatch-insight-eventbridge-event-count-by-source/snippet.txt
@@ -1,0 +1,3 @@
+fields @timestamp
+| stats count(*) as EventsCountBySource by source
+| sort @timestamp desc

--- a/cloudwatch-insight-eventbridge-event-detail-field-within-a-numeric-range/sample-data.json
+++ b/cloudwatch-insight-eventbridge-event-detail-field-within-a-numeric-range/sample-data.json
@@ -1,0 +1,34 @@
+{
+    "title": "Events with detail field value falling in a given numeric range ",
+    "description": "Get the EventBridge events for a given detail field that has values within a given numeric range",
+    "type": "CloudWatch Logs Insights",
+    "services": [],
+    "tags": [
+      ""
+    ],
+    "introBox": {
+      "headline": "How it works",
+      "text": ["Cloudwatch Log Insight snippet that returns the EventBridge events for a given detail field that has values within a given numeric range"]
+    },
+    "gitHub": {
+      "template": {
+        "repoURL": "https://github.com/aws-samples/serverless-snippets/tree/main/cloudwatch-insight-eventbridge-event-detail-field-within-a-numeric-range"
+      }
+    },
+    "snippets": [
+      {
+        "snippetPath": "snippet.txt",
+        "language": "css"
+      }
+    ],
+    "authors": [
+      {
+        "headline": "Presented by Rahul Sringeri",
+        "name": "Rahul Sringeri",
+        "image": "",
+        "bio": "Technical Account Manager at AWS for Strategic Accounts",
+        "linkedin": "",
+        "twitter": ""
+      }
+    ]
+  }

--- a/cloudwatch-insight-eventbridge-event-detail-field-within-a-numeric-range/snippet.txt
+++ b/cloudwatch-insight-eventbridge-event-detail-field-within-a-numeric-range/snippet.txt
@@ -1,0 +1,3 @@
+fields @timestamp
+| filter detail.field-value >= N1 and detail.field-value <= N2 # replace field-value, N1, N2 with actual values. N1 and N2 are the numeric range.
+| sort @timestamp desc

--- a/cloudwatch-insight-eventbridge-event-filter-by-detail-field-equal-to/sample-data.json
+++ b/cloudwatch-insight-eventbridge-event-filter-by-detail-field-equal-to/sample-data.json
@@ -1,0 +1,35 @@
+{
+    "title": "Filter Events by value of a detail field",
+    "description": "Get the EventBridge events by filtering on a detail field",
+    "type": "CloudWatch Logs Insights",
+    "services": [],
+    "tags": [
+      ""
+    ],
+    "introBox": {
+      "headline": "How it works",
+      "text": ["Cloudwatch Log Insight snippet that filters the EventBridge events by value of a detail field"]
+    },
+    "gitHub": {
+      "template": {
+        "repoURL": "https://github.com/aws-samples/serverless-snippets/tree/main/cloudwatch-insight-eventbridge-event-filter-by-detail-field"
+      }
+    },
+    "snippets": [
+      {
+        "snippetPath": "snippet.txt",
+        "language": "css"
+      }
+    ],
+    "authors": [
+      {
+        "headline": "Presented by Rahul Sringeri",
+        "name": "Rahul Sringeri",
+        "image": "",
+        "bio": "Technical Account Manager at AWS for Strategic Accounts",
+        "linkedin": "",
+        "twitter": ""
+      }
+    ]
+  }
+  

--- a/cloudwatch-insight-eventbridge-event-filter-by-detail-field-equal-to/snippet.txt
+++ b/cloudwatch-insight-eventbridge-event-filter-by-detail-field-equal-to/snippet.txt
@@ -1,0 +1,3 @@
+fields @timestamp
+| filter detail.field-name = "field-value"   # replace field-name and field-value with actual values
+| sort @timestamp desc

--- a/cloudwatch-insight-eventbridge-event-filter-by-detail-field-not-equal-to/sample-data.json
+++ b/cloudwatch-insight-eventbridge-event-filter-by-detail-field-not-equal-to/sample-data.json
@@ -1,0 +1,34 @@
+{
+    "title": "Filter Events by detail field value not equal to a given value",
+    "description": "Get the EventBridge events by filtering on a detail field value that is not equal to a given value ",
+    "type": "CloudWatch Logs Insights",
+    "services": [],
+    "tags": [
+      ""
+    ],
+    "introBox": {
+      "headline": "How it works",
+      "text": ["Cloudwatch Log Insight snippet that filters the EventBridge events on a detail field value not equal to a given value"]
+    },
+    "gitHub": {
+      "template": {
+        "repoURL": "https://github.com/aws-samples/serverless-snippets/tree/main/cloudwatch-insight-eventbridge-event-filter-by-detail-field-not-equal-to"
+      }
+    },
+    "snippets": [
+      {
+        "snippetPath": "snippet.txt",
+        "language": "css"
+      }
+    ],
+    "authors": [
+      {
+        "headline": "Presented by Rahul Sringeri",
+        "name": "Rahul Sringeri",
+        "image": "",
+        "bio": "Technical Account Manager at AWS for Strategic Accounts",
+        "linkedin": "",
+        "twitter": ""
+      }
+    ]
+  }

--- a/cloudwatch-insight-eventbridge-event-filter-by-detail-field-not-equal-to/snippet.txt
+++ b/cloudwatch-insight-eventbridge-event-filter-by-detail-field-not-equal-to/snippet.txt
@@ -1,0 +1,3 @@
+fields @timestamp
+| filter detail.field-name != "field-value"   # replace field-name and field-value with actual values
+| sort @timestamp desc

--- a/cloudwatch-insight-eventbridge-event-filter-by-detail-type-equal-to/sample-data.json
+++ b/cloudwatch-insight-eventbridge-event-filter-by-detail-type-equal-to/sample-data.json
@@ -1,0 +1,35 @@
+{
+    "title": "Events that match the value of detail-type",
+    "description": "Get the EventBridge events that match the value of detail-type",
+    "type": "CloudWatch Logs Insights",
+    "services": [],
+    "tags": [
+      ""
+    ],
+    "introBox": {
+      "headline": "How it works",
+      "text": ["Cloudwatch Log Insight snippet that filters the EventBridge events by value of detail-type"]
+    },
+    "gitHub": {
+      "template": {
+        "repoURL": "https://github.com/aws-samples/serverless-snippets/tree/main/cloudwatch-insight-eventbridge-event-filter-by-detail-type"
+      }
+    },
+    "snippets": [
+      {
+        "snippetPath": "snippet.txt",
+        "language": "css"
+      }
+    ],
+    "authors": [
+      {
+        "headline": "Presented by Rahul Sringeri",
+        "name": "Rahul Sringeri",
+        "image": "",
+        "bio": "Technical Account Manager at AWS for Strategic Accounts",
+        "linkedin": "",
+        "twitter": ""
+      }
+    ]
+  }
+  

--- a/cloudwatch-insight-eventbridge-event-filter-by-detail-type-equal-to/snippet.txt
+++ b/cloudwatch-insight-eventbridge-event-filter-by-detail-type-equal-to/snippet.txt
@@ -1,0 +1,3 @@
+fields @timestamp
+| filter `detail-type` = "detail-type-value"    # replace detail-type-value with the actual value
+| sort @timestamp desc

--- a/cloudwatch-insight-eventbridge-event-filter-detail-field-with-values-in-array/sample-data.json
+++ b/cloudwatch-insight-eventbridge-event-filter-detail-field-with-values-in-array/sample-data.json
@@ -1,0 +1,35 @@
+{
+    "title": "Events that match a value in detail-field that has an array of values",
+    "description": "Get the EventBridge events that match a value in detail-field that has an array of values",
+    "type": "CloudWatch Logs Insights",
+    "services": [],
+    "tags": [
+      ""
+    ],
+    "introBox": {
+      "headline": "How it works",
+      "text": ["Cloudwatch Log Insight snippet that gets the EventBridge events that matches a value in detail-field that has an array of values"]
+    },
+    "gitHub": {
+      "template": {
+        "repoURL": "https://github.com/aws-samples/serverless-snippets/tree/main/cloudwatch-insight-eventbridge-event-filter-detail-field-with-values-in-array"
+      }
+    },
+    "snippets": [
+      {
+        "snippetPath": "snippet.txt",
+        "language": "css"
+      }
+    ],
+    "authors": [
+      {
+        "headline": "Presented by Rahul Sringeri",
+        "name": "Rahul Sringeri",
+        "image": "",
+        "bio": "Technical Account Manager at AWS for Strategic Accounts",
+        "linkedin": "",
+        "twitter": ""
+      }
+    ]
+  }
+  

--- a/cloudwatch-insight-eventbridge-event-filter-detail-field-with-values-in-array/snippet.txt
+++ b/cloudwatch-insight-eventbridge-event-filter-detail-field-with-values-in-array/snippet.txt
@@ -1,0 +1,3 @@
+fields @timestamp
+| filter detail.array-field.n1 = "sample-value"  # replace array-field with the field name having values as array, n1 with array position and sample-value with value to filter. 
+| sort @timestamp desc

--- a/cloudwatch-insight-eventbridge-event-find-if-detail-field-exists/sample-data.json
+++ b/cloudwatch-insight-eventbridge-event-find-if-detail-field-exists/sample-data.json
@@ -1,0 +1,35 @@
+{
+    "title": "Get Events if a given detail field is present ",
+    "description": "Get the EventBridge events if detail field is present",
+    "type": "CloudWatch Logs Insights",
+    "services": [],
+    "tags": [
+      ""
+    ],
+    "introBox": {
+      "headline": "How it works",
+      "text": ["Cloudwatch Log Insight snippet that returns the EventBridge events if a given detail field is present"]
+    },
+    "gitHub": {
+      "template": {
+        "repoURL": "https://github.com/aws-samples/serverless-snippets/tree/main/cloudwatch-insight-eventbridge-event-find-if-detail-field-exists"
+      }
+    },
+    "snippets": [
+      {
+        "snippetPath": "snippet.txt",
+        "language": "css"
+      }
+    ],
+    "authors": [
+      {
+        "headline": "Presented by Rahul Sringeri",
+        "name": "Rahul Sringeri",
+        "image": "",
+        "bio": "Technical Account Manager at AWS for Strategic Accounts",
+        "linkedin": "",
+        "twitter": ""
+      }
+    ]
+  }
+  

--- a/cloudwatch-insight-eventbridge-event-find-if-detail-field-exists/snippet.txt
+++ b/cloudwatch-insight-eventbridge-event-find-if-detail-field-exists/snippet.txt
@@ -1,0 +1,3 @@
+fields @timestamp
+| filter ispresent(detail.field-name)    # replace field-name with the actual value
+| sort @timestamp desc

--- a/cloudwatch-insight-eventbridge-event-per-hour/sample-data.json
+++ b/cloudwatch-insight-eventbridge-event-per-hour/sample-data.json
@@ -1,0 +1,34 @@
+{
+    "title": "Events per hour ",
+    "description": "Get the EventBridge events per hour",
+    "type": "CloudWatch Logs Insights",
+    "services": [],
+    "tags": [
+      ""
+    ],
+    "introBox": {
+      "headline": "How it works",
+      "text": ["Cloudwatch Log Insight snippet that returns the EventBridge events per hour"]
+    },
+    "gitHub": {
+      "template": {
+        "repoURL": "https://github.com/aws-samples/serverless-snippets/tree/main/cloudwatch-insight-eventbridge-event-per-minute"
+      }
+    },
+    "snippets": [
+      {
+        "snippetPath": "snippet.txt",
+        "language": "css"
+      }
+    ],
+    "authors": [
+      {
+        "headline": "Presented by Rahul Sringeri",
+        "name": "Rahul Sringeri",
+        "image": "",
+        "bio": "Technical Account Manager at AWS for Strategic Accounts",
+        "linkedin": "",
+        "twitter": ""
+      }
+    ]
+  }

--- a/cloudwatch-insight-eventbridge-event-per-hour/snippet.txt
+++ b/cloudwatch-insight-eventbridge-event-per-hour/snippet.txt
@@ -1,0 +1,4 @@
+fields @timestamp
+| filter ispresent(`detail-type`)
+| stats count(*) as CountOfEventsPerHour by bin(1h)
+| sort @timestamp desc

--- a/cloudwatch-insight-eventbridge-event-per-minute/sample-data.json
+++ b/cloudwatch-insight-eventbridge-event-per-minute/sample-data.json
@@ -1,0 +1,34 @@
+{
+    "title": "Events per minute ",
+    "description": "Get the EventBridge events per minute",
+    "type": "CloudWatch Logs Insights",
+    "services": [],
+    "tags": [
+      ""
+    ],
+    "introBox": {
+      "headline": "How it works",
+      "text": ["Cloudwatch Log Insight snippet that returns the EventBridge events per minute"]
+    },
+    "gitHub": {
+      "template": {
+        "repoURL": "https://github.com/aws-samples/serverless-snippets/tree/main/cloudwatch-insight-eventbridge-event-per-minute"
+      }
+    },
+    "snippets": [
+      {
+        "snippetPath": "snippet.txt",
+        "language": "css"
+      }
+    ],
+    "authors": [
+      {
+        "headline": "Presented by Rahul Sringeri",
+        "name": "Rahul Sringeri",
+        "image": "",
+        "bio": "Technical Account Manager at AWS for Strategic Accounts",
+        "linkedin": "",
+        "twitter": ""
+      }
+    ]
+  }

--- a/cloudwatch-insight-eventbridge-event-per-minute/snippet.txt
+++ b/cloudwatch-insight-eventbridge-event-per-minute/snippet.txt
@@ -1,0 +1,4 @@
+fields @timestamp
+| filter ispresent(`detail-type`)
+| stats count(*) as CountOfEventsPerMinute by bin(1m)
+| sort @timestamp desc

--- a/cloudwatch-insight-eventbridge-event-where-detail-field-value-in/sample-data.json
+++ b/cloudwatch-insight-eventbridge-event-where-detail-field-value-in/sample-data.json
@@ -1,0 +1,34 @@
+{
+    "title": "Events with detail field that matches any value in a list ",
+    "description": "Get the EventBridge events with a specific detail field that matches any value in a list.",
+    "type": "CloudWatch Logs Insights",
+    "services": [],
+    "tags": [
+      ""
+    ],
+    "introBox": {
+      "headline": "How it works",
+      "text": ["Cloudwatch Log Insight snippet that returns the EventBridge events for a given detail field that that matches any value in a list"]
+    },
+    "gitHub": {
+      "template": {
+        "repoURL": "https://github.com/aws-samples/serverless-snippets/tree/main/cloudwatch-insight-eventbridge-event-where-detail-field-value-in"
+      }
+    },
+    "snippets": [
+      {
+        "snippetPath": "snippet.txt",
+        "language": "css"
+      }
+    ],
+    "authors": [
+      {
+        "headline": "Presented by Rahul Sringeri",
+        "name": "Rahul Sringeri",
+        "image": "",
+        "bio": "Technical Account Manager at AWS for Strategic Accounts",
+        "linkedin": "",
+        "twitter": ""
+      }
+    ]
+  }

--- a/cloudwatch-insight-eventbridge-event-where-detail-field-value-in/snippet.txt
+++ b/cloudwatch-insight-eventbridge-event-where-detail-field-value-in/snippet.txt
@@ -1,0 +1,3 @@
+fields @timestamp
+| filter detail.field-value IN ["value1", "value2", "value3"]  # replace field-value and value1, value2, value3 with actual values.
+| sort @timestamp desc

--- a/cloudwatch-insight-eventbridge-event-where-detail-field-value-not-in/sample-data.json
+++ b/cloudwatch-insight-eventbridge-event-where-detail-field-value-not-in/sample-data.json
@@ -1,0 +1,34 @@
+{
+    "title": "Events with detail field that does not match any value in a list ",
+    "description": "Get the EventBridge events with a specific detail field that does not match any value in a list.",
+    "type": "CloudWatch Logs Insights",
+    "services": [],
+    "tags": [
+      ""
+    ],
+    "introBox": {
+      "headline": "How it works",
+      "text": ["Cloudwatch Log Insight snippet that returns the EventBridge events for a given detail field that that does not matches any value in a list"]
+    },
+    "gitHub": {
+      "template": {
+        "repoURL": "https://github.com/aws-samples/serverless-snippets/tree/main/cloudwatch-insight-eventbridge-event-where-detail-field-value-not-in"
+      }
+    },
+    "snippets": [
+      {
+        "snippetPath": "snippet.txt",
+        "language": "css"
+      }
+    ],
+    "authors": [
+      {
+        "headline": "Presented by Rahul Sringeri",
+        "name": "Rahul Sringeri",
+        "image": "",
+        "bio": "Technical Account Manager at AWS for Strategic Accounts",
+        "linkedin": "",
+        "twitter": ""
+      }
+    ]
+  }

--- a/cloudwatch-insight-eventbridge-event-where-detail-field-value-not-in/snippet.txt
+++ b/cloudwatch-insight-eventbridge-event-where-detail-field-value-not-in/snippet.txt
@@ -1,0 +1,3 @@
+fields @timestamp
+| filter detail.field-value NOT IN ["value1", "value2", "value3"]  # replace field-value and value1, value2, value3 with actual values.
+| sort @timestamp desc

--- a/cloudwatch-insight-eventbridge-event-where-value-equals-nested-detail-field-value/sample-data.json
+++ b/cloudwatch-insight-eventbridge-event-where-value-equals-nested-detail-field-value/sample-data.json
@@ -1,0 +1,35 @@
+{
+    "title": "Events that match a value in detail-nested-field",
+    "description": "Get the EventBridge events that match a value in detail-nested-field",
+    "type": "CloudWatch Logs Insights",
+    "services": [],
+    "tags": [
+      ""
+    ],
+    "introBox": {
+      "headline": "How it works",
+      "text": ["Cloudwatch Log Insight snippet that gets the EventBridge events that matches a value in detail-nested-field"]
+    },
+    "gitHub": {
+      "template": {
+        "repoURL": "https://github.com/aws-samples/serverless-snippets/tree/main/cloudwatch-insight-eventbridge-event-where-value-equals-nested-detail-field-value"
+      }
+    },
+    "snippets": [
+      {
+        "snippetPath": "snippet.txt",
+        "language": "css"
+      }
+    ],
+    "authors": [
+      {
+        "headline": "Presented by Rahul Sringeri",
+        "name": "Rahul Sringeri",
+        "image": "",
+        "bio": "Technical Account Manager at AWS for Strategic Accounts",
+        "linkedin": "",
+        "twitter": ""
+      }
+    ]
+  }
+  

--- a/cloudwatch-insight-eventbridge-event-where-value-equals-nested-detail-field-value/snippet.txt
+++ b/cloudwatch-insight-eventbridge-event-where-value-equals-nested-detail-field-value/snippet.txt
@@ -1,0 +1,3 @@
+fields @timestamp
+| filter detail.field1.field2 = "sample-value"  # replace field1, field2, sample-value with appropriate values.
+| sort @timestamp desc

--- a/cloudwatch-insight-eventbridge-event-with-detail-field-empty/sample-data.json
+++ b/cloudwatch-insight-eventbridge-event-with-detail-field-empty/sample-data.json
@@ -1,0 +1,34 @@
+{
+    "title": "Events which have no value for a given detail field ",
+    "description": "Get the EventBridge events for a given detail field that has no value",
+    "type": "CloudWatch Logs Insights",
+    "services": [],
+    "tags": [
+      ""
+    ],
+    "introBox": {
+      "headline": "How it works",
+      "text": ["Cloudwatch Log Insight snippet that returns the EventBridge events for a given detail field that has no value"]
+    },
+    "gitHub": {
+      "template": {
+        "repoURL": "https://github.com/aws-samples/serverless-snippets/tree/main/cloudwatch-insight-eventbridge-event-with-detail-field-empty"
+      }
+    },
+    "snippets": [
+      {
+        "snippetPath": "snippet.txt",
+        "language": "css"
+      }
+    ],
+    "authors": [
+      {
+        "headline": "Presented by Rahul Sringeri",
+        "name": "Rahul Sringeri",
+        "image": "",
+        "bio": "Technical Account Manager at AWS for Strategic Accounts",
+        "linkedin": "",
+        "twitter": ""
+      }
+    ]
+  }

--- a/cloudwatch-insight-eventbridge-event-with-detail-field-empty/snippet.txt
+++ b/cloudwatch-insight-eventbridge-event-with-detail-field-empty/snippet.txt
@@ -1,0 +1,3 @@
+fields @timestamp
+| filter isempty(detail.field-value)   # replace field-value with the actual value
+| sort @timestamp desc


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Created 14 new query snippets that can be used in CloudWatch Log Insights to query events from EventBridge. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
