### PR TITLE
Expand Lambda-S3 serverless example metadata

### DIFF
--- a/.doc_gen/metadata/serverless_metadata.yaml
+++ b/.doc_gen/metadata/serverless_metadata.yaml
@@ -14,9 +14,12 @@ serverless_S3_Lambda:
             - description: Consuming an S3 event with Lambda using JavaScript.
               snippet_files:
                 - integration-s3-to-lambda/example.js
+            - description: Consuming an S3 event with Lambda using TypeScript.
+              snippet_files:
+                - integration-s3-to-lambda/example.ts
     Python:
       versions:
-        - sdk_version: 2
+        - sdk_version: 3
           github: https://github.com/aws-samples/serverless-snippets/tree/main/integration-s3-to-lambda
           excerpts:
             - description: Consuming an S3 event with Lambda using Python.
@@ -32,7 +35,7 @@ serverless_S3_Lambda:
                 - integration-s3-to-lambda/Handler.java
     .NET:
       versions:
-        - sdk_version: 2
+        - sdk_version: 3
           github: https://github.com/aws-samples/serverless-snippets/tree/main/integration-s3-to-lambda
           excerpts:
             - description: Consuming an S3 event with Lambda using .NET.
@@ -46,17 +49,9 @@ serverless_S3_Lambda:
             - description: Consuming an S3 event with Lambda using Go.
               snippet_files:
                 - integration-s3-to-lambda/main.go
-    TypeScript:
-      versions:
-        - sdk_version: 2
-          github: https://github.com/aws-samples/serverless-snippets/tree/main/integration-s3-to-lambda
-          excerpts:
-            - description: Consuming an S3 event with Lambda using TypeScript.
-              snippet_files:
-                - integration-s3-to-lambda/example.ts
     Rust:
       versions:
-        - sdk_version: 2
+        - sdk_version: 1
           github: https://github.com/aws-samples/serverless-snippets/tree/main/integration-s3-to-lambda
           excerpts:
             - description: Consuming an S3 event with Lambda using Rust.

--- a/.doc_gen/metadata/serverless_metadata.yaml
+++ b/.doc_gen/metadata/serverless_metadata.yaml
@@ -14,6 +14,54 @@ serverless_S3_Lambda:
             - description: Consuming an S3 event with Lambda using JavaScript.
               snippet_files:
                 - integration-s3-to-lambda/example.js
+    Python:
+      versions:
+        - sdk_version: 2
+          github: https://github.com/aws-samples/serverless-snippets/tree/main/integration-s3-to-lambda
+          excerpts:
+            - description: Consuming an S3 event with Lambda using Python.
+              snippet_files:
+                - integration-s3-to-lambda/example.py
+    Java:
+      versions:
+        - sdk_version: 2
+          github: https://github.com/aws-samples/serverless-snippets/tree/main/integration-s3-to-lambda
+          excerpts:
+            - description: Consuming an S3 event with Lambda using Java.
+              snippet_files:
+                - integration-s3-to-lambda/Handler.java
+    .NET:
+      versions:
+        - sdk_version: 2
+          github: https://github.com/aws-samples/serverless-snippets/tree/main/integration-s3-to-lambda
+          excerpts:
+            - description: Consuming an S3 event with Lambda using .NET.
+              snippet_files:
+                - integration-s3-to-lambda/Function.cs
+    Go:
+      versions:
+        - sdk_version: 2
+          github: https://github.com/aws-samples/serverless-snippets/tree/main/integration-s3-to-lambda
+          excerpts:
+            - description: Consuming an S3 event with Lambda using Go.
+              snippet_files:
+                - integration-s3-to-lambda/main.go
+    TypeScript:
+      versions:
+        - sdk_version: 2
+          github: https://github.com/aws-samples/serverless-snippets/tree/main/integration-s3-to-lambda
+          excerpts:
+            - description: Consuming an S3 event with Lambda using TypeScript.
+              snippet_files:
+                - integration-s3-to-lambda/example.ts
+    Rust:
+      versions:
+        - sdk_version: 2
+          github: https://github.com/aws-samples/serverless-snippets/tree/main/integration-s3-to-lambda
+          excerpts:
+            - description: Consuming an S3 event with Lambda using Rust.
+              snippet_files:
+                - integration-s3-to-lambda/main.rs
   services:
     lambda:
     s3:


### PR DESCRIPTION
Expand Lambda-S3 serverless example metadata to include Python, Java, .NET, Go, TS, Rust

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
