### PR TITLE
Add existing Python, Java samples to Kinesis+batch failures

### DIFF
--- a/.doc_gen/metadata/serverless_metadata.yaml
+++ b/.doc_gen/metadata/serverless_metadata.yaml
@@ -212,6 +212,22 @@ serverless_Kinesis_Lambda_batch_item_failures:
             - description: Reporting Kinesis batch item failures with Lambda using .NET.
               snippet_files:
                 - integration-kinesis-to-lambda-with-batch-item-handling/Function.cs
+    Python:
+      versions:
+        - sdk_version: 3
+          github: https://github.com/aws-samples/serverless-snippets/tree/main/integration-kinesis-to-lambda-with-batch-item-handling
+          excerpts:
+            - description: Reporting Kinesis batch item failures with Lambda using Python.
+              snippet_files:
+                - integration-kinesis-to-lambda-with-batch-item-handling/example.py
+    Java:
+      versions:
+        - sdk_version: 2
+          github: https://github.com/aws-samples/serverless-snippets/tree/main/integration-kinesis-to-lambda-with-batch-item-handling
+          excerpts:
+            - description: Reporting Kinesis batch item failures with Lambda using Java.
+              snippet_files:
+                - integration-kinesis-to-lambda-with-batch-item-handling/example.java
   services:
     lambda:
     kinesis:

--- a/integration-kinesis-to-lambda-with-batch-item-handling/example.java
+++ b/integration-kinesis-to-lambda-with-batch-item-handling/example.java
@@ -1,0 +1,34 @@
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+import com.amazonaws.services.lambda.runtime.events.KinesisEvent;
+import com.amazonaws.services.lambda.runtime.events.StreamsEventResponse;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+public class ProcessKinesisRecords implements RequestHandler<KinesisEvent, StreamsEventResponse> {
+
+    @Override
+    public StreamsEventResponse handleRequest(KinesisEvent input, Context context) {
+
+        List<StreamsEventResponse.BatchItemFailure> batchItemFailures = new ArrayList<>();
+        String curRecordSequenceNumber = "";
+
+        for (KinesisEvent.KinesisEventRecord kinesisEventRecord : input.getRecords()) {
+            try {
+                //Process your record
+                KinesisEvent.Record kinesisRecord = kinesisEventRecord.getKinesis();
+                curRecordSequenceNumber = kinesisRecord.getSequenceNumber();
+
+            } catch (Exception e) {
+                /* Since we are working with streams, we can return the failed item immediately.
+                   Lambda will immediately begin to retry processing from this failed item onwards. */
+                batchItemFailures.add(new StreamsEventResponse.BatchItemFailure(curRecordSequenceNumber));
+                return new StreamsEventResponse(batchItemFailures);
+            }
+        }
+       
+       return new StreamsEventResponse(batchItemFailures);   
+    }
+}

--- a/integration-kinesis-to-lambda-with-batch-item-handling/example.py
+++ b/integration-kinesis-to-lambda-with-batch-item-handling/example.py
@@ -1,0 +1,13 @@
+def handler(event, context):
+    records = event.get("Records")
+    curRecordSequenceNumber = ""
+    
+    for record in records:
+        try:
+            # Process your record
+            curRecordSequenceNumber = record["kinesis"]["sequenceNumber"]
+        except Exception as e:
+            # Return failed record's sequence number
+            return {"batchItemFailures":[{"itemIdentifier": curRecordSequenceNumber}]}
+
+    return {"batchItemFailures":[]}

--- a/integration-kinesis-to-lambda-with-batch-item-handling/snippet-data.json
+++ b/integration-kinesis-to-lambda-with-batch-item-handling/snippet-data.json
@@ -43,6 +43,28 @@
           ]
         },
         {
+          "id": "Java",
+          "title": "Usage Example with Java:",
+          "description": "Consuming Kinesis event with Lambda using Java with batch item handling.",
+          "snippets": [
+            {
+              "snippetPath": "example.java",
+              "language": "java"
+            }
+          ]
+        },
+        {
+          "id": "Python",
+          "title": "Usage Example with Python:",
+          "description": "Consuming Kinesis event with Lambda using Python with batch item handling.",
+          "snippets": [
+            {
+              "snippetPath": "example.py",
+              "language": "py"
+            }
+          ]
+        },
+        {
           "id": ".NET",
           "title": "Usage Example with .NET:",
           "description": "Consuming Kinesis event with Lambda using .NET with batch item handling.",


### PR DESCRIPTION
Adds existing Python, Java samples in https://docs.aws.amazon.com/lambda/latest/dg/with-kinesis.html#services-kinesis-batchfailurereporting into the repo.

Also adds Tributaries metadata for automated integration with this page of the Lambda dev guide.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
