### PR TITLE
Add rust snippet for SQSBatchResponse

### DIFF
--- a/lambda-function-sqs-report-batch-item-failures/example.rs
+++ b/lambda-function-sqs-report-batch-item-failures/example.rs
@@ -1,0 +1,30 @@
+use aws_lambda_events::{
+    event::sqs::{SqsBatchResponse, SqsEvent},
+    sqs::{BatchItemFailure, SqsMessage},
+};
+use lambda_runtime::{run, service_fn, Error, LambdaEvent};
+
+async fn process_record(_: &SqsMessage) -> Result<(), Error> {
+    Err(Error::from("Error processing message"))
+}
+
+async fn function_handler(event: LambdaEvent<SqsEvent>) -> Result<SqsBatchResponse, Error> {
+    let mut batch_item_failures = Vec::new();
+    for record in event.payload.records {
+        match process_record(&record).await {
+            Ok(_) => (),
+            Err(_) => batch_item_failures.push(BatchItemFailure {
+                item_identifier: record.message_id.unwrap(),
+            }),
+        }
+    }
+
+    Ok(SqsBatchResponse {
+        batch_item_failures,
+    })
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Error> {
+    run(service_fn(function_handler)).await
+}

--- a/lambda-function-sqs-report-batch-item-failures/snippet-data.json
+++ b/lambda-function-sqs-report-batch-item-failures/snippet-data.json
@@ -3,7 +3,7 @@
   "description": "This snippet demonstrates how to handle an SQS event and implement a partial batch response in a lambda function.",
   "type": "Integration",
   "services": ["lambda", "sqs"],
-  "languages": ["Java", "Python", ".NET"],
+  "languages": ["Java", "Python", ".NET", "Rust"],
   "tags": ["Amazon SQS", "Handling Errors"],
   "introBox": {
     "headline": "How it works",
@@ -52,6 +52,17 @@
               "language": "dotnet"
             }
           ]
+        },
+        {
+          "id": "Rust",
+          "title": "Usage Example with Rust:",
+          "description": "Implementing partial SQS batch responses using Rust.",
+          "snippets": [
+            {
+              "snippetPath": "example.rs",
+              "language": "rust"
+            }
+          ]
         }
       ]
     }
@@ -71,6 +82,14 @@
       "image": "https://avatars.githubusercontent.com/u/14178747?s=400&v=4",
       "bio": "Sr. Solutions Architect at AWS",
       "linkedin": "victorfeinman",
+      "twitter": ""
+    },
+    {
+      "headline": "Rust example by Charles Ede",
+      "name": "Charles Ede",
+      "image": "https://avatars.githubusercontent.com/u/22171170?s=400&v=4",
+      "bio": "Sr. Engineer at LEGO",
+      "linkedin": "",
       "twitter": ""
     }
   ]


### PR DESCRIPTION
Add a Rust snippet for SQSBatchResponse, I have tried to keep the example as similar to the others as I can, except in Rust it is commonplace to use `Result` types rather than `try catch`.

Can I add a github profile? rather than linkedin/twitter for author credits?

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
