### PR TITLE
Add Rust snippet for integration-sns-to-lambda

### DIFF
--- a/integration-sns-to-lambda/lambda-sns-receive.rs
+++ b/integration-sns-to-lambda/lambda-sns-receive.rs
@@ -1,0 +1,38 @@
+use aws_lambda_events::event::sns::SnsEvent;
+use aws_lambda_events::sns::SnsRecord;
+use lambda_runtime::{run, service_fn, Error, LambdaEvent};
+use tracing::info;
+
+// Built with the following dependencies:
+//  aws_lambda_events = { version = "0.10.0", default-features = false, features = ["sns"] }
+//  lambda_runtime = "0.8.1"
+//  tokio = { version = "1", features = ["macros"] }
+//  tracing = { version = "0.1", features = ["log"] }
+//  tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt"] }
+
+async fn function_handler(event: LambdaEvent<SnsEvent>) -> Result<(), Error> {
+    for event in event.payload.records {
+        process_record(&event)?;
+    }
+    
+    Ok(())
+}
+
+fn process_record(record: &SnsRecord) -> Result<(), Error> {
+    info!("Processing SNS Message: {}", record.sns.message);
+
+    // Implement your record handling code here.
+
+    Ok(())
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Error> {
+    tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::INFO)
+        .with_target(false)
+        .without_time()
+        .init();
+
+    run(service_fn(function_handler)).await
+}

--- a/integration-sns-to-lambda/snippet-data.json
+++ b/integration-sns-to-lambda/snippet-data.json
@@ -3,7 +3,7 @@
   "description": "Using an Amazon SNS trigger to invoke a Lambda function",
   "type": "Integration",
   "services": ["lambda", "sns"],
-  "languages": ["Node", "Python", ".NET", "TypeScript"],
+  "languages": ["Node", "Python", ".NET", "TypeScript", "Rust"],
   "tags": [],
   "introBox": {
     "headline": "How it works",
@@ -61,6 +61,17 @@
             {
               "snippetPath": "example.py",
               "language": "py"
+            }
+          ]
+        },
+        {
+          "id": "Rust",
+          "title": "Usage Example with Rust:",
+          "description": "Consuming an SNS event with Lambda using Rust.",
+          "snippets": [
+            {
+              "snippetPath": "lambda-sns-receive.rs",
+              "language": "rust"
             }
           ]
         }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Add a rust snippet for the integration-sns-to-lambda example


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
