### PR TITLE
Corrected sqs-report-batch-item-failures example for TypeScript

### DIFF
--- a/lambda-function-sqs-report-batch-item-failures/snippet-data.json
+++ b/lambda-function-sqs-report-batch-item-failures/snippet-data.json
@@ -87,6 +87,17 @@
           ]
         },
         {
+          "id": "TypeScript",
+          "title": "Usage example with TypeScript:",
+          "description": "Implementing partial SQS batch responses using TypeScript.",
+          "snippets": [
+            {
+              "snippetPath": "example.ts",
+              "language": "ts"
+            }
+          ]
+        },
+        {
           "id": "PHP",
           "title": "Usage Example with PHP:",
           "description": "Implementing partial SQS batch responses using PHP.",


### PR DESCRIPTION
*Description of changes:* Changed request and response types for `lambda-function-sqs-report-batch-item-failures` TypeScript example to use SQS request/response types. Esbuild output almost exactly matches the JavaScript example.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
