### PR TITLE
PHP Example for DynamoDB batch item handling

### DIFF
--- a/integration-ddb-to-lambda-with-batch-item-handling/example.php
+++ b/integration-ddb-to-lambda-with-batch-item-handling/example.php
@@ -1,0 +1,60 @@
+<?php
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# using bref/bref and bref/logger for simplicity
+
+use Bref\Context\Context;
+use Bref\Event\DynamoDb\DynamoDbEvent;
+use Bref\Event\Handler as StdHandler;
+use Bref\Logger\StderrLogger;
+
+require __DIR__ . '/vendor/autoload.php';
+
+class Handler implements StdHandler
+{
+    private StderrLogger $logger;
+    public function __construct(StderrLogger $logger)
+    {
+        $this->logger = $logger;
+    }
+
+    /**
+     * @throws JsonException
+     * @throws \Bref\Event\InvalidLambdaEvent
+     */
+    public function handle(mixed $event, Context $context): array
+    {
+        $dynamoDbEvent = new DynamoDbEvent($event);
+        $this->logger->info("Processing records");
+
+        $records = $dynamoDbEvent->getRecords();
+        $failedRecords = [];
+        foreach ($records as $record) {
+            try {
+                $data = $record->getData();
+                $this->logger->info(json_encode($data));
+                // TODO: Do interesting work based on the new data
+            } catch (Exception $e) {
+                $this->logger->error($e->getMessage());
+                // failed processing the record
+                $failedRecords[] = $record->getSequenceNumber();
+            }
+        }
+        $totalRecords = count($records);
+        $this->logger->info("Successfully processed $totalRecords records");
+
+        // change format for the response
+        $failures = array_map(
+            fn(string $sequenceNumber) => ['itemIdentifier' => $sequenceNumber],
+            $failedRecords
+        );
+
+        return [
+            'batchItemFailures' => $failures
+        ];
+    }
+}
+
+$logger = new StderrLogger();
+return new Handler($logger);


### PR DESCRIPTION
Following the other PHP examples - using Bref's classes for type safety.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
