### PR TITLE
Added Golang samples for Lambda connection with RDS using IAM and Lambda integration with DocDB

### DIFF
--- a/integration-docdb-to-lambda/main.go
+++ b/integration-docdb-to-lambda/main.go
@@ -1,0 +1,48 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/aws/aws-lambda-go/lambda"
+)
+
+type Event struct {
+	Events []Record `json:"events"`
+}
+
+type Record struct {
+	Event struct {
+		OperationType string `json:"operationType"`
+		NS            struct {
+			DB   string `json:"db"`
+			Coll string `json:"coll"`
+		} `json:"ns"`
+		FullDocument interface{} `json:"fullDocument"`
+	} `json:"event"`
+}
+
+func main() {
+	lambda.Start(handler)
+}
+
+func handler(ctx context.Context, event Event) (string, error) {
+	fmt.Println("Loading function")
+	for _, record := range event.Events {
+		logDocumentDBEvent(record)
+	}
+
+	return "OK", nil
+}
+
+func logDocumentDBEvent(record Record) {
+	fmt.Printf("Operation type: %s\n", record.Event.OperationType)
+	fmt.Printf("db: %s\n", record.Event.NS.DB)
+	fmt.Printf("collection: %s\n", record.Event.NS.Coll)
+	docBytes, _ := json.MarshalIndent(record.Event.FullDocument, "", "  ")
+	fmt.Printf("Full document: %s\n", string(docBytes))
+}

--- a/lambda-function-connect-rds-iam/main.go
+++ b/lambda-function-connect-rds-iam/main.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+
+	"github.com/aws/aws-lambda-go/lambda"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/feature/rds/auth"
+	_ "github.com/go-sql-driver/mysql"
+)
+
+type MyEvent struct {
+	Name string `json:"name"`
+}
+
+func HandleRequest(event *MyEvent) (map[string]interface{}, error) {
+
+	var dbName string = "DatabaseName"
+	var dbUser string = "DatabaseUser"
+	var dbHost string = "mysqldb.123456789012.us-east-1.rds.amazonaws.com"
+	var dbPort int = 3306
+	var dbEndpoint string = fmt.Sprintf("%s:%d", dbHost, dbPort)
+	var region string = "us-east-1"
+
+	cfg, err := config.LoadDefaultConfig(context.TODO())
+	if err != nil {
+		panic("configuration error: " + err.Error())
+	}
+
+	authenticationToken, err := auth.BuildAuthToken(
+		context.TODO(), dbEndpoint, region, dbUser, cfg.Credentials)
+	if err != nil {
+		panic("failed to create authentication token: " + err.Error())
+	}
+
+	dsn := fmt.Sprintf("%s:%s@tcp(%s)/%s?tls=true&allowCleartextPasswords=true",
+		dbUser, authenticationToken, dbEndpoint, dbName,
+	)
+
+	db, err := sql.Open("mysql", dsn)
+	if err != nil {
+		panic(err)
+	}
+
+	defer db.Close()
+
+	var sum int
+	err = db.QueryRow("SELECT ?+? AS sum", 3, 2).Scan(&sum)
+	if err != nil {
+		panic(err)
+	}
+	s := fmt.Sprint(sum)
+	message := fmt.Sprintf("The selected sum is: %s", s)
+
+	messageBytes, err := json.Marshal(message)
+	if err != nil {
+		return nil, err
+	}
+
+	messageString := string(messageBytes)
+	return map[string]interface{}{
+		"statusCode": 200,
+		"headers":    map[string]string{"Content-Type": "application/json"},
+		"body":       messageString,
+	}, nil
+}
+
+func main() {
+	lambda.Start(HandleRequest)
+}

--- a/lambda-function-connect-rds-iam/main.go
+++ b/lambda-function-connect-rds-iam/main.go
@@ -1,3 +1,9 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+/*
+Golang v2 code here.
+*/
+
 package main
 
 import (


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Added Golang samples for Lambda connection with RDS using IAM and Lambda integration with DocDB
For RDS 2nd commit is to add Copyright header. Code tested thoroughly on AL2023 runtime.
For DocDB the code is tested on Runtime al2023 as per the documentation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
