### PR TITLE
Fix incorrect return value of DDB Lambda with Batch Item Handling TypeScript snippet

### DIFF
--- a/integration-ddb-to-lambda-with-batch-item-handling/example.ts
+++ b/integration-ddb-to-lambda-with-batch-item-handling/example.ts
@@ -1,21 +1,26 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { DynamoDBBatchItemFailure, DynamoDBStreamEvent } from "aws-lambda";
+import {
+  DynamoDBBatchResponse,
+  DynamoDBBatchItemFailure,
+  DynamoDBStreamEvent,
+} from "aws-lambda";
 
-export const handler = async (event: DynamoDBStreamEvent): Promise<DynamoDBBatchItemFailure[]> => {
+export const handler = async (
+  event: DynamoDBStreamEvent
+): Promise<DynamoDBBatchResponse> => {
+  const batchItemFailures: DynamoDBBatchItemFailure[] = [];
+  let curRecordSequenceNumber;
 
-    const batchItemsFailures: DynamoDBBatchItemFailure[] = []
-    let curRecordSequenceNumber
+  for (const record of event.Records) {
+    curRecordSequenceNumber = record.dynamodb?.SequenceNumber;
 
-    for(const record of event.Records) {
-        curRecordSequenceNumber = record.dynamodb?.SequenceNumber
-
-        if(curRecordSequenceNumber) {
-            batchItemsFailures.push({
-                itemIdentifier: curRecordSequenceNumber
-            })
-        }
+    if (curRecordSequenceNumber) {
+      batchItemFailures.push({
+        itemIdentifier: curRecordSequenceNumber,
+      });
     }
+  }
 
-    return batchItemsFailures
-}
+  return { batchItemFailures: batchItemFailures };
+};


### PR DESCRIPTION
Return value of the TypeScript code snippet was incorrect as it was just an array.

This PR fixes the incorrect return value and changes the return type to DynamoDBBatchResponse as a guardrail, as implementing this type would have highlighted the issue with the return value in an editor.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
