### PR TITLE
Update example.js

### DIFF
--- a/integration-s3-to-lambda/example.js
+++ b/integration-s3-to-lambda/example.js
@@ -4,7 +4,7 @@ import { S3Client, HeadObjectCommand } from "@aws-sdk/client-s3";
 
 const client = new S3Client();
 
-exports.handler = async (event, context) => {
+export const handler = async (event, context) => {
 
     // Get the object from the event and show its content type
     const bucket = event.Records[0].s3.bucket.name;


### PR DESCRIPTION
Change handler definition to use ES module format

*Description of changes:*
Current node.js example code for the S3 trigger tutorial uses an ES module style import statement, but declares the handler in common JS format. Changed the handler definition to use ES module format.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
