### PR TITLE
Change tj-actions reference to SHA in workflow

### DIFF
--- a/.github/workflows/schema-validation-for-snippet.yml
+++ b/.github/workflows/schema-validation-for-snippet.yml
@@ -15,7 +15,7 @@ jobs:
 
       - name: Get changed files using defaults
         id: changed-files
-        uses: tj-actions/changed-files@v41
+        uses: tj-actions/changed-files@df3e9932c48cda43e6e09567f3a1ce1b38ca76e9
         with:
           separator: ","    
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- To prevent against confused actor attack via upstream repository. Reference: https://www.synacktiv.com/publications/github-actions-exploitation-dependabot

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
