### PR TITLE
Changed the return type of the RequestHandler interface from generic …

### DIFF
--- a/integration-ddb-to-lambda-with-batch-item-handling/example.java
+++ b/integration-ddb-to-lambda-with-batch-item-handling/example.java
@@ -6,11 +6,10 @@ import com.amazonaws.services.lambda.runtime.events.DynamodbEvent;
 import com.amazonaws.services.lambda.runtime.events.StreamsEventResponse;
 import com.amazonaws.services.lambda.runtime.events.models.dynamodb.StreamRecord;
 
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
-public class ProcessDynamodbRecords implements RequestHandler<DynamodbEvent, Serializable> {
+public class ProcessDynamodbRecords implements RequestHandler<DynamodbEvent, StreamsEventResponse> {
 
     @Override
     public StreamsEventResponse handleRequest(DynamodbEvent input, Context context) {


### PR DESCRIPTION
Changed the return type of the RequestHandler interface from generic Serializable to specific StreamsEventResponse for better type safety and clarity

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
