### PR TITLE
Including lambda log insights duration

### DIFF
--- a/lambda-loginsights-duration/README.md
+++ b/lambda-loginsights-duration/README.md
@@ -1,0 +1,10 @@
+<div align="center">
+
+<h1>Explore <a href="https://serverlessland.com">ServerlessLand</a></h1>
+
+
+![ServerlessLand.com](../serverlessland.png)
+[Explore 700+ patterns](https://serverlessland.com/patterns?ref=github-snippets) | [Explore 50+ guides](https://serverlessland.com/learn?ref=github-snippets) | [Explore 80+ guides](https://serverlessland.com/snippets?ref=github-snippets)
+
+</div>
+

--- a/lambda-loginsights-duration/snippet-data.json
+++ b/lambda-loginsights-duration/snippet-data.json
@@ -1,0 +1,31 @@
+{
+  "title": "Lambda invocations with duration greater than a specific threshold",
+  "description": "Returns the list of Lambda invocations with duration greater than specific thereshold",
+  "type": "CloudWatch Logs Insights",
+  "services": ["lambda"],
+  "tags": ["Testing"],
+  "introBox": {
+    "headline": "How it works",
+    "text": ["Cloudwatch Log Insights snippet that lists the invocations with duration greater than the specified thereshold of your Lambda Lambda function."
+          ]
+  },
+  "gitHub": {
+    "template": {
+      "repoURL": "https://github.com/aws-samples/serverless-snippets/tree/main/lambda-loginsights-duration"
+    }
+  },
+  "snippets": [
+    {
+      "title": "Copy the code into CloudWatch log insights",
+      "snippetPath": "snippet.txt",
+      "language": "css"
+    }
+  ],
+  "authors": {
+    "headline": "Presented by Pallavi Bhat",
+    "name": "Pallavi Bhat",
+    "imageURL": "https://drive.google.com/file/d/1xYr8HfVnLZOMmhAc9hSsyj_O85yyznF7/view?usp=sharing",
+    "linkedin": "https://www.linkedin.com/in/pallavi-bhat11/",
+    "bio": "Cloud Support Engineer at AWS."
+  }
+}

--- a/lambda-loginsights-duration/snippet.txt
+++ b/lambda-loginsights-duration/snippet.txt
@@ -1,0 +1,5 @@
+fields @timestamp, @message
+|filter @type = "REPORT" 
+| parse @message /Duration: (?<duration>.*?) ms/
+| filter duration > 1000
+| sort by duration desc


### PR DESCRIPTION
*Issue #, if available:* NA

*Description of changes:*
This is a serverlessland snippet that provides a CloudWatch log insights query to list out the Lambda function invocations that resulted in duration higher than the defined threshold. This is useful when the customers needs to find the invocation that resulted in an alarm (cloudwatch).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
