### PR TITLE
apigateway-mock-integration-binary-media-types Snippet

### DIFF
--- a/apigateway-mock-integration-binary-media-types/README.md
+++ b/apigateway-mock-integration-binary-media-types/README.md
@@ -1,0 +1,26 @@
+## Amazon API Gateway Access Logging Setup
+
+This snippet assumes that Amazon API Gateway logs requests to Amazon CloudWatch Logs using JSON and the following log format:
+
+```json
+{ 
+"requestId":"$context.requestId", 
+"ip": "$context.identity.sourceIp", 
+"apiKey": "$context.identity.apiKey", 
+"requestTime":"$context.requestTime", 
+"httpMethod":"$context.httpMethod",
+"routeKey":"$context.routeKey", 
+"path":"$context.path", 
+"status": $context.status,
+"protocol":"$context.protocol", 
+"integrationStatus": $context.integrationStatus, 
+"integrationLatency": $context.integrationLatency, 
+"responseLatency":$context.responseLatency, 
+"responseLength": $context.responseLength 
+}
+```
+
+You can modify log format to fit your needs (make sure to update code snippet if field names change). 
+
+
+See documentation for more details on how to set up API Gateway logging in HTTP (https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-logging.html) and REST (https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-logging.html) APIs.

--- a/apigateway-mock-integration-binary-media-types/snippet-data.json
+++ b/apigateway-mock-integration-binary-media-types/snippet-data.json
@@ -1,0 +1,36 @@
+{
+  "title": "Disable Content-Type conversion in Mock integration",
+  "description": "Using AWS CLI to disable Content-Type conversion in MOCK integration when Binary media types are enabled on API Gateway.",
+  "type": "Integration",
+  "services": ["apigw"],
+  "tags": ["API Gateway"],
+  "languages": ["bash"],
+  "introBox": {
+    "headline": "How it works",
+    "text": [
+      "When Binary Media Types are enabled on a REST API with '/' or 'application/json', API Gateway converts payloads based on Content-Type headers, but MOCK integrations don't support binary content. This often results in 500 error.",
+      "To resolve this, the Content Handling behavior must be set to 'CONVERT_TO_TEXT' for the Integration request, which can only be done via AWS CLI and not via the console at the moment."
+    ]
+  },
+  "gitHub": {
+    "template": {
+      "repoURL": "https://github.com/aws-samples/serverless-snippets/tree/main/apigateway-mock-integration-binary-media-types"
+    }
+  },
+  "snippets": [
+    {
+      "title": "The contentHandling property of the MOCK Integration can be set to CONVERT_TO_TEXT using the following CLI command (NOTE: replace the API ID, resource ID and AWS region):",
+      "snippetPath": "snippet.txt",
+      "language": "cli" 
+    }
+  ],
+  "authors": [
+    {
+      "headline": "Presented by Pallavi Bhat",
+      "name": "Pallavi Bhat",
+      "image": "https://drive.google.com/file/d/1xYr8HfVnLZOMmhAc9hSsyj_O85yyznF7/view?usp=drive_link",
+      "bio": "Pallavi is a Cloud Support Enginner focusing on serverless at Amazon Web Services.",
+      "linkedin": "https://www.linkedin.com/in/pallavi-bhat11/"
+    }
+  ]
+}

--- a/apigateway-mock-integration-binary-media-types/snippet.txt
+++ b/apigateway-mock-integration-binary-media-types/snippet.txt
@@ -1,0 +1,1 @@
+aws apigateway update-integration --rest-api-id <your-rest-api-id> --resource-id <resource-id> --http-method OPTIONS --patch-operations "op='replace' ,path='/contentHandling' ,value='CONVERT_TO_TEXT'" --region <region-of-api>


### PR DESCRIPTION
*Issue #, if available:* NA

*Description of changes:*
This is a serverlessland snippet that provides AWS CLI command to modify the content-handling property of REST API MOCK integration when binary media types are enabled on the API Gateway. This feature is currently not available on console. Hence this CLI command is used.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
