### PR TITLE
apigateway-log-insights-caching snippet

### DIFF
--- a/apigateway-log-insights-caching/README.md
+++ b/apigateway-log-insights-caching/README.md
@@ -1,0 +1,26 @@
+## Amazon API Gateway Access Logging Setup
+
+This snippet assumes that Amazon API Gateway logs requests to Amazon CloudWatch Logs using JSON and the following log format:
+
+```json
+{ 
+"requestId":"$context.requestId", 
+"ip": "$context.identity.sourceIp", 
+"apiKey": "$context.identity.apiKey", 
+"requestTime":"$context.requestTime", 
+"httpMethod":"$context.httpMethod",
+"routeKey":"$context.routeKey", 
+"path":"$context.path", 
+"status": $context.status,
+"protocol":"$context.protocol", 
+"integrationStatus": $context.integrationStatus, 
+"integrationLatency": $context.integrationLatency, 
+"responseLatency":$context.responseLatency, 
+"responseLength": $context.responseLength 
+}
+```
+
+You can modify log format to fit your needs (make sure to update code snippet if field names change). 
+
+
+See documentation for more details on how to set up API Gateway logging in HTTP (https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-logging.html) and REST (https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-logging.html) APIs.

--- a/apigateway-log-insights-caching/snippet-access.txt
+++ b/apigateway-log-insights-caching/snippet-access.txt
@@ -1,0 +1,6 @@
+fields @timestamp, @message
+| parse @message '"requestId":"*"' as requestId
+| parse @message '"IntegrationLatency":"*"' as IntegrationLatency
+| filter ispresent(IntegrationLatency)
+| sort by @timestamp desc
+| display @timestamp, requestId, IntegrationLatency

--- a/apigateway-log-insights-caching/snippet-data.json
+++ b/apigateway-log-insights-caching/snippet-data.json
@@ -1,0 +1,55 @@
+{
+  "title": "Find if the API requests are being served from Cache",
+  "description": "Provides CloudWatch log insights queries to find the requests served from Cache",
+  "type": "Integration",
+  "services": ["apigw"],
+  "tags": [],
+  "languages": ["css"],
+  "introBox": {
+    "headline": "How it works",
+    "text": [
+      "Caching is a feature of API Gateway which stores and reuses API responses for a specified TTL enhancing the responsiveness of the API. ",
+      "One way to monitor if the requests are being served from cache or no is by using the API Gateway CacheMissCount and CacheHitCount CloudWatch metrics. The periodic pattern in the metric graph display the caching behavior."
+      "Another approach to check specifically which all requests are served from cache or backend, given the access logs or execution logs have been enabled on the API Gateway is using the following CloudWatch log insight queries."
+    ]
+  },
+  "gitHub": {
+    "template": {
+      "repoURL": "https://github.com/aws-samples/serverless-snippets/tree/main/apigateway-log-insights-caching"
+    }
+  },
+  "snippets": [
+    {
+      "title": [
+        "For Access logs:",
+        "NOTE: The access log format must contain $context.integrationLatency access logging variable which will log the integration latency of the request. Change the requestId and IntegrationLatency filters as per the logging format you have"
+    
+    ],
+      "snippetPath": "snippet-access.txt",
+      "language": "css"
+    },
+    {
+      "title": [
+        "For Execution logs:",
+        "NOTE: Requires Error and Info logs with Data tracing enabled."
+    
+    ],
+      "snippetPath": "snippet-execution.txt",
+      "language": "css"
+    },
+    {
+      "title": "Following query can be used to list the requests which were not served from cache:",
+      "snippetPath": "snippet-execution-ca.txt",
+      "language": "css"
+    }
+  ],
+  "authors": [
+    {
+      "headline": "Presented by Pallavi Bhat",
+      "name": "Pallavi Bhat",
+      "image": "https://drive.google.com/file/d/1xYr8HfVnLZOMmhAc9hSsyj_O85yyznF7/view?usp=sharing",
+      "bio": "Pallavi is a Cloud Support Enginner focusing on serverless at Amazon Web Services.",
+      "linkedin": "https://www.linkedin.com/in/pallavi-bhat11/"
+    }
+  ]
+}

--- a/apigateway-log-insights-caching/snippet-execution-ca.txt
+++ b/apigateway-log-insights-caching/snippet-execution-ca.txt
@@ -1,0 +1,7 @@
+fields @timestamp, @message
+| filter @message like 'Integration latency'
+| parse @message /Integration latency: (?<IntegrationLatency>.*?) ms/
+| parse @message /(?<requestID>[0-9a-zA-Z-]{36}).*/
+| filter IntegrationLatency > 0
+| sort by @timestamp desc
+| display timestamp, IntegrationLatency, requestID

--- a/apigateway-log-insights-caching/snippet-execution.txt
+++ b/apigateway-log-insights-caching/snippet-execution.txt
@@ -1,0 +1,6 @@
+fields @timestamp, @message
+| filter @message like 'Integration latency'
+| parse @message /Integration latency: (?<IntegrationLatency>.*?) ms/
+| parse @message /(?<requestID>[0-9a-zA-Z-]{36}).*/
+| sort by @timestamp desc
+| display @timestamp, requestID, IntegrationLatency


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This snippet provides the CloudWatch log insights query to fetch the requests of the API  Gateway that were served from Cache. This makes use of both access logs and execution logs.
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
