### PR TITLE
cloudwatch-loginsights-connect-contactid query

### DIFF
--- a/cloudwatch-loginsights-connect-contactid/README.md
+++ b/cloudwatch-loginsights-connect-contactid/README.md
@@ -1,0 +1,10 @@
+<div align="center">
+
+<h1>Explore <a href="https://serverlessland.com">ServerlessLand</a></h1>
+
+
+![ServerlessLand.com](../serverlessland.png)
+[Explore 700+ patterns](https://serverlessland.com/patterns?ref=github-snippets) | [Explore 50+ guides](https://serverlessland.com/learn?ref=github-snippets) | [Explore 80+ guides](https://serverlessland.com/snippets?ref=github-snippets)
+
+</div>
+

--- a/cloudwatch-loginsights-connect-contactid/snippet-data.json
+++ b/cloudwatch-loginsights-connect-contactid/snippet-data.json
@@ -1,0 +1,31 @@
+{
+  "title": "Find the Contact Flow logs of specific contact ID in Amazon Connect",
+  "description": "Returns the contact flow logs for the specific Contact ID and if it returned any error",
+  "type": "CloudWatch Logs Insights",
+  "services": ["connect", "lambda"],
+  "tags": ["Testing"],
+  "introBox": {
+    "headline": "How it works",
+    "text": ["Cloudwatch Log Insights snippet that provides the logs of the specific contact ID if it resulted in any error"
+          ]
+  },
+  "gitHub": {
+    "template": {
+      "repoURL": "https://github.com/aws-samples/serverless-snippets/tree/main/cloudwatch-loginsights-connect-contactid"
+    }
+  },
+  "snippets": [
+    {
+      "title": "Copy the code into CloudWatch log insights",
+      "snippetPath": "snippet.txt",
+      "language": "css"
+    }
+  ],
+  "authors": {
+    "headline": "Presented by Pallavi Bhat",
+    "name": "Pallavi Bhat",
+    "imageURL": "https://drive.google.com/file/d/1xYr8HfVnLZOMmhAc9hSsyj_O85yyznF7/view?usp=sharing",
+    "linkedin": "https://www.linkedin.com/in/pallavi-bhat11/",
+    "bio": "Cloud Support Engineer at AWS."
+  }
+}

--- a/cloudwatch-loginsights-connect-contactid/snippet.txt
+++ b/cloudwatch-loginsights-connect-contactid/snippet.txt
@@ -1,0 +1,4 @@
+fields @timestamp, @message
+| sort @timestamp desc
+| filter ContactId = "1234abc-456d-4ef-ghi-96c9631f2a95"
+| filter Results LIKE "Error"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This snippet provides a CloudWatch log insight query to find if the specific contact ID in Amazon Connect resulted in any error from Lambda

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
