### PR TITLE
Fix Golang: lambda-function-sqs-report-batch-item-failures

### DIFF
--- a/lambda-function-sqs-report-batch-item-failures/example.go
+++ b/lambda-function-sqs-report-batch-item-failures/example.go
@@ -4,7 +4,6 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-lambda-go/lambda"
@@ -14,8 +13,12 @@ func handler(ctx context.Context, sqsEvent events.SQSEvent) (map[string]interfac
 	batchItemFailures := []map[string]interface{}{}
 
 	for _, message := range sqsEvent.Records {
-		
-		if /* Your message processing condition here */ {			
+		if len(message.Body) > 0 {
+			// Your message processing condition here
+			fmt.Printf("Successfully processed message: %s\n", message.Body)
+		} else {
+			// Message processing failed
+			fmt.Printf("Failed to process message %s\n", message.Body)
 			batchItemFailures = append(batchItemFailures, map[string]interface{}{"itemIdentifier": message.MessageId})
 		}
 	}

--- a/lambda-function-sqs-report-batch-item-failures/example.go
+++ b/lambda-function-sqs-report-batch-item-failures/example.go
@@ -4,7 +4,6 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-lambda-go/lambda"
@@ -14,8 +13,12 @@ func handler(ctx context.Context, sqsEvent events.SQSEvent) (map[string]interfac
 	batchItemFailures := []map[string]interface{}{}
 
 	for _, message := range sqsEvent.Records {
-		
-		if /* Your message processing condition here */ {			
+		if len(message.Body) > 0 {
+			// Your message processing condition here
+			fmt.Printf("Successfully processed message: %s\n", message.Body)
+		} else {
+			// Message processing failed
+			fmt.Printf("Failed to process message %s\n", message.MessageId)
 			batchItemFailures = append(batchItemFailures, map[string]interface{}{"itemIdentifier": message.MessageId})
 		}
 	}

--- a/lambda-function-sqs-report-batch-item-failures/example.go
+++ b/lambda-function-sqs-report-batch-item-failures/example.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-lambda-go/lambda"
@@ -13,12 +14,8 @@ func handler(ctx context.Context, sqsEvent events.SQSEvent) (map[string]interfac
 	batchItemFailures := []map[string]interface{}{}
 
 	for _, message := range sqsEvent.Records {
-		if len(message.Body) > 0 {
-			// Your message processing condition here
-			fmt.Printf("Successfully processed message: %s\n", message.Body)
-		} else {
-			// Message processing failed
-			fmt.Printf("Failed to process message %s\n", message.Body)
+		
+		if /* Your message processing condition here */ {			
 			batchItemFailures = append(batchItemFailures, map[string]interface{}{"itemIdentifier": message.MessageId})
 		}
 	}

--- a/lambda-function-sqs-report-batch-item-failures/example.py
+++ b/lambda-function-sqs-report-batch-item-failures/example.py
@@ -8,7 +8,7 @@ def lambda_handler(event, context):
      
         for record in event["Records"]:
             try:
-                # process message
+                print(f"Processed message: {record['body']}")
             except Exception as e:
                 batch_item_failures.append({"itemIdentifier": record['messageId']})
         


### PR DESCRIPTION
*Description of changes:*
The Golang example for SQS processing has a placeholder for message processing. Without manually amending the code, this causes the build process to fail as there's no actual condition. 
Suggested fix is adding a log line, similar to other examples which prints the message body to show success.
The other issue is all records would go to the `batchItemFailures` so adding an else statement.
Also removed `encoding/json` as not used.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
