### PR TITLE
Remove unused messageId String

### DIFF
--- a/lambda-function-sqs-report-batch-item-failures/example.java
+++ b/lambda-function-sqs-report-batch-item-failures/example.java
@@ -11,9 +11,8 @@ import java.util.List;
 public class ProcessSQSMessageBatch implements RequestHandler<SQSEvent, SQSBatchResponse> {
     @Override
     public SQSBatchResponse handleRequest(SQSEvent sqsEvent, Context context) {
- 
          List<SQSBatchResponse.BatchItemFailure> batchItemFailures = new ArrayList<SQSBatchResponse.BatchItemFailure>();
-         String messageId = "";
+
          for (SQSEvent.SQSMessage message : sqsEvent.getRecords()) {
              try {
                  //process your message


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Removed unused messageId string from Java `lambda-function-sqs-report-batch-item-failures` example


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
