### PR TITLE
Fixing the Go implementation to loop through all failures

### DIFF
--- a/integration-ddb-to-lambda-with-batch-item-handling/example.go
+++ b/integration-ddb-to-lambda-with-batch-item-handling/example.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"context"
+
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-lambda-go/lambda"
 )
@@ -18,22 +19,21 @@ type BatchResult struct {
 
 func HandleRequest(ctx context.Context, event events.DynamoDBEvent) (*BatchResult, error) {
 	var batchItemFailures []BatchItemFailure
-	curRecordSequenceNumber := ""
 
 	for _, record := range event.Records {
-		// Process your record
-		curRecordSequenceNumber = record.Change.SequenceNumber
+		if err := processRecord(record); err != nil {
+			batchItemFailures = append(batchItemFailures, BatchItemFailure{
+				ItemIdentifier: record.Change.SequenceNumber,
+			})
+		}
 	}
 
-	if curRecordSequenceNumber != "" {
-		batchItemFailures = append(batchItemFailures, BatchItemFailure{ItemIdentifier: curRecordSequenceNumber})
-	}
-	
-	batchResult := BatchResult{
-		BatchItemFailures: batchItemFailures,
-	}
+	return &BatchResult{BatchItemFailures: batchItemFailures}, nil
+}
 
-	return &batchResult, nil
+func processRecord(record events.DynamoDBEventRecord) error {
+	// Your processing logic here
+	return nil
 }
 
 func main() {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Capture all batch changes in a loop:

```
	for _, record := range event.Records {
		if err := processRecord(record); err != nil {
			batchItemFailures = append(batchItemFailures, BatchItemFailure{
				ItemIdentifier: record.Change.SequenceNumber,
			})
		}
	}
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
