### PR TITLE
Anandoo7 feature lambda disable recursion protection

### DIFF
--- a/apigateway-JWT-auth-header-extraction-mapping-template/README.md
+++ b/apigateway-JWT-auth-header-extraction-mapping-template/README.md
@@ -1,0 +1,30 @@
+## Amazon API Gateway Access Logging Setup
+
+This snippet assumes that Amazon API Gateway logs requests to Amazon CloudWatch Logs using JSON and the following log format:
+
+```json
+{ 
+"requestId": "$context.requestId", 
+"ip": "$context.identity.sourceIp", 
+"apiKey": "$context.identity.apiKey", 
+"requestTime": "$context.requestTime", 
+"httpMethod": "$context.httpMethod",
+"routeKey": "$context.routeKey", 
+"path":"$context.path", 
+"status": "$context.status",
+"protocol": "$context.protocol", 
+"integrationStatus": "$context.integrationStatus", 
+"integrationLatency": "$context.integrationLatency", 
+"responseLatency": "$context.responseLatency", 
+"responseLength": "$context.responseLength" 
+}
+```
+
+You can modify log format to fit your needs (make sure to update code snippet if field names change). 
+
+
+See documentation 
+1. For more details on how to set up API Gateway logging in [HTTP](https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-logging.html) and [REST](https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-logging.html) APIs.
+2. [Overriding request/response parameters and response status in Amazon API Gateway](https://aws.amazon.com/blogs/compute/overriding-request-response-parameters-and-response-status-in-amazon-api-gateway/)
+3. [Context variable reference](https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-mapping-template-reference.html#context-variable-reference)
+4. [Velocity template](https://velocity.apache.org/engine/devel/vtl-reference.html)

--- a/apigateway-JWT-auth-header-extraction-mapping-template/snippet-all-headers.txt
+++ b/apigateway-JWT-auth-header-extraction-mapping-template/snippet-all-headers.txt
@@ -1,0 +1,16 @@
+#set($authHeaderValue = $input.params().header.get('Authorization'))
+#if($authHeaderValue.startsWith('Bearer '))
+  #set($clientId = $authHeaderValue.substring(7))
+  #set($allHeaders = $input.params().header)
+  #set($entry = {})
+  $util.qr($allHeaders.put('clientId', $clientId))
+  $util.toJson($input.json('$'))
+#else
+  $util.badRequest("Missing or invalid 'Authorization' header")
+#end
+
+{
+  "method": "$context.httpMethod",
+  "body" : $input.json('$'),
+  "headers": "$util.escapeJavaScript($allHeaders)"
+}

--- a/apigateway-JWT-auth-header-extraction-mapping-template/snippet-data.json
+++ b/apigateway-JWT-auth-header-extraction-mapping-template/snippet-data.json
@@ -1,0 +1,36 @@
+{
+  "title": "[[your title]]",
+  "description": "[[ your description ]]",
+  "type": "CloudWatch Logs Insights",
+  "services": ["lambda"],
+  "tags": [],
+  "languages": [],
+  "introBox": {
+    "headline": "How it works",
+    "text": [
+      "[[description of how the snippet works]]"
+    ]
+  },
+  "gitHub": {
+    "template": {
+      "repoURL": "https://github.com/aws-samples/serverless-snippets/tree/main/cloudwatch-insight-exception-per-hour"
+    }
+  },
+  "snippets": [
+    {
+      "title": "Copy the code into CloudWatch Logs Insights",
+      "snippetPath": "snippet.txt",
+      "language": "css" // use css for cloudwatch (looks good), or find your language from https://prismjs.com/#languages-list
+    }
+  ],
+  "authors": [
+    {
+      "headline": "Presented by [[your name]]",
+      "name": "[[your name]]",
+      "image": "link-to-your-photo.jpg",
+      "bio": "Your bio",
+      "linkedin": "linked-in-ID",
+      "twitter": "twitter-handle"
+    }
+  ]
+}

--- a/apigateway-JWT-auth-header-extraction-mapping-template/snippet-data.json
+++ b/apigateway-JWT-auth-header-extraction-mapping-template/snippet-data.json
@@ -1,36 +1,52 @@
 {
-  "title": "[[your title]]",
-  "description": "[[ your description ]]",
-  "type": "CloudWatch Logs Insights",
-  "services": ["lambda"],
+  "title": "Extract a JWT token from the auth header into a new backend header",
+  "description": "Extract a part of JWT token from the Authorization header and pass it on to the backend integrations as a separate header",
+  "type": "Integration",
+  "services": ["apigw"],
   "tags": [],
-  "languages": [],
+  "languages": ["vtl"],
   "introBox": {
     "headline": "How it works",
     "text": [
-      "[[description of how the snippet works]]"
+      "This snippet can be used to extract a part of JWT token from the Authorization header and pass it on to the backend integrations as a separate header using Mapping template.",
+      "Integration request parameters, in the form of headers, can be mapped from any defined method request parameters and the payload.",
+      "One can make use of Method request header along with the mapping expression method.request.header.PARAM_NAME to achieve this use case.",
+      "1. Set up a Method Request by configuring an HTTP method (ANY, DELETE, GET, HEAD, OPTIONS, PATCH, POST, PUT) for your API Gateway resource with a backend integration.",
+      "2. In the Method Request tab, click edit and add a new HTTP request header name (e.g., clientId) that will be sent to the backend. Avoid restricted header names per AWS documentation.",
+      "3. After adding the header in Method Request settings, navigate to the Integration Request section where your backend integration endpoint is configured.",
+      "4. Expand URL request headers parameters and add a mapping entry using the expression method.request.header.clientId to forward the header to the integration.",
+      "5. This maps the incoming method request header value and passes it as a separate header to the backend integration endpoint."
     ]
   },
   "gitHub": {
     "template": {
-      "repoURL": "https://github.com/aws-samples/serverless-snippets/tree/main/cloudwatch-insight-exception-per-hour"
+      "repoURL": "https://github.com/aws-samples/serverless-snippets/tree/main/apigateway-JWT-auth-header-extraction-mapping-template"
     }
   },
   "snippets": [
     {
-      "title": "Copy the code into CloudWatch Logs Insights",
-      "snippetPath": "snippet.txt",
-      "language": "css" // use css for cloudwatch (looks good), or find your language from https://prismjs.com/#languages-list
+      "title": "To pass only a new header to the backend: Add the following mapping template body that fetches the header named Authorization from the request, validates if the header value starts with ‘Bearer’ and extracts a part of the value for the new clientId header. Then context.responseOverride.header.<header_name> is used for overriding the header. Use the content types as application/json.",
+      "snippetPath": "snippet-only-new-header.txt",
+      "language": "vtl"
+    },
+    {
+      "title": "To append the new header to the list of headers and send it along with all the headers to the backend, use the following template.",
+      "snippetPath": "snippet-all-headers.txt",
+      "language": "vtl"
+    },
+    {
+      "title": "Invoke the API using the invoke URL along with an Authorization header. For example “Authorization: Bearer a1b2c3d4e5f6g7.h8i9j0k1l2m3n4o5p6.q7r8s9t0u1v2w3x4y5z” is being passed as the token header. Please ensure to use your API Gateway’s invoke URL.",
+      "snippetPath": "snippet-test.txt",
+      "language": "cli"
     }
   ],
   "authors": [
     {
-      "headline": "Presented by [[your name]]",
-      "name": "[[your name]]",
-      "image": "link-to-your-photo.jpg",
-      "bio": "Your bio",
-      "linkedin": "linked-in-ID",
-      "twitter": "twitter-handle"
+      "headline": "Presented by Annangarachari R",
+      "name": "Annangarachari R",
+      "image": "https://media.licdn.com/dms/image/v2/D5603AQGJ4TjBa44wFg/profile-displayphoto-scale_400_400/B56Z5Y28nWGgAo-/0/1779607260719?e=1781136000&v=beta&t=pou5fuFAMTmw7PuyTc2Jli6aYkWqnLhqHgzw-Bn9pDI",
+      "bio": "Serverless Enthusiast",
+      "linkedin": "https://www.linkedin.com/in/annangarachari-r/"
     }
   ]
 }

--- a/apigateway-JWT-auth-header-extraction-mapping-template/snippet-only-new-header.txt
+++ b/apigateway-JWT-auth-header-extraction-mapping-template/snippet-only-new-header.txt
@@ -1,0 +1,16 @@
+#set($authHeaderValue = $input.params().header.get('Authorization'))
+#if($authHeaderValue.startsWith('Bearer '))
+  #set($clientId = $authHeaderValue.substring(7))
+  #set($context.requestOverrideConfiguration.headers.clientId = $clientId)
+$util.toJson($input.json('$'))
+#else
+$util.badRequest("Missing or invalid 'Authorization' header")
+#end
+
+{ 
+  "method": "$context.httpMethod",
+  "body" : $input.json('$'),
+  "headers": { 
+       "clientId": "$util.escapeJavaScript($clientId)"
+  }
+}

--- a/apigateway-JWT-auth-header-extraction-mapping-template/snippet-test.txt
+++ b/apigateway-JWT-auth-header-extraction-mapping-template/snippet-test.txt
@@ -1,0 +1,5 @@
+curl --location 'https://abcde1234.execute-api.us-east-1.amazonaws.com/Stage/Resource-1’ \
+--header 'Authorization: Bearer a1b2c3d4e5f6g7.h8i9j0k1l2m3n4o5p6.q7r8s9t0u1v2w3x4y5z' \
+--header 'Cloud: AWS' \   
+--header 'Content-Type: application/json' \
+--data '{"Condition”:”Check the headers”}’

--- a/apigateway-JWT-auth-header-extraction-mapping-template/snippet.txt
+++ b/apigateway-JWT-auth-header-extraction-mapping-template/snippet.txt
@@ -1,0 +1,3 @@
+filter @message like /Exception/ 
+  | stats count(*) as exceptionCount by bin(1h)
+  | sort exceptionCount desc

--- a/apigateway-JWT-auth-header-extraction-mapping-template/snippet.txt
+++ b/apigateway-JWT-auth-header-extraction-mapping-template/snippet.txt
@@ -1,3 +1,0 @@
-filter @message like /Exception/ 
-  | stats count(*) as exceptionCount by bin(1h)
-  | sort exceptionCount desc

--- a/aws-cli-lambda-rate-exceeded-source/README.md
+++ b/aws-cli-lambda-rate-exceeded-source/README.md
@@ -1,0 +1,10 @@
+<div align="center">
+
+<h1>Explore <a href="https://serverlessland.com">ServerlessLand</a></h1>
+
+
+![ServerlessLand.com](../serverlessland.png)
+[Explore 700+ patterns](https://serverlessland.com/patterns?ref=github-snippets) | [Explore 50+ guides](https://serverlessland.com/learn?ref=github-snippets) | [Explore 80+ guides](https://serverlessland.com/snippets?ref=github-snippets)
+
+</div>
+

--- a/aws-cli-lambda-rate-exceeded-source/snippet-data.json
+++ b/aws-cli-lambda-rate-exceeded-source/snippet-data.json
@@ -1,0 +1,42 @@
+{
+  "title": "Using CloudTrail LookupEvents to Identify the Source of Lambda Rate Exceeded Errors",
+  "description": "Use AWS CloudTrail LookupEvents to identify which IAM identity or service is triggering 'Rate exceeded' throttling errors on Lambda management API calls.",
+  "type": "AWS CLI",
+  "services": ["lambda"],
+  "tags": ["debugging"],
+  "languages": ["bash","aws cli"],
+  "introBox": {
+    "headline": "How it works",
+    "text": [
+      "You might receive a 'Rate exceeded' error when your environment exceeds Lambda function quota limits for API requests. Before you can resolve a 'Rate exceeded' error, review your CloudTrail event logs using the following commands"
+    ]
+  },
+  "gitHub": {
+    "template": {
+      "repoURL": "https://github.com/aws-samples/serverless-snippets/tree/main/aws-cli-lambda-rate-exceeded-source"
+    }
+  },
+  "snippets": [
+    {
+      "title": ["Run the CloudTrail lookup-events AWS Command Line Interface (AWS CLI) command to view the total count of management event API calls.",
+               "Note- Set the start-time, the end-time, and the time zone for each value to match the problematic timeframe."],
+      "snippetPath": "snippet-total.txt",
+      "language": "cli"
+    },
+    {
+      "title": ["Run the CloudTrail lookup-events command to view the total count of API calls made by each user.",
+                "Note: Set the start-time, the end-time, and the time zone for each value to match the problematic timeframe."],
+      "snippetPath": "snippet-users.txt",
+      "language": "cli"
+    }
+  ],
+  "authors": [
+    {
+      "headline": "Presented by Annangarachari R",
+      "name": "Annangarachari R",
+      "image": "https://media.licdn.com/dms/image/v2/D5603AQGJ4TjBa44wFg/profile-displayphoto-scale_400_400/B56Z5Y28nWGgAo-/0/1779607260719?e=1781136000&v=beta&t=pou5fuFAMTmw7PuyTc2Jli6aYkWqnLhqHgzw-Bn9pDI",
+      "bio": "Serverless Enthusiast",
+      "linkedin": "https://www.linkedin.com/in/annangarachari-r/"
+    }
+  ]
+}

--- a/aws-cli-lambda-rate-exceeded-source/snippet-total.txt
+++ b/aws-cli-lambda-rate-exceeded-source/snippet-total.txt
@@ -1,0 +1,1 @@
+aws cloudtrail lookup-events --lookup-attributes AttributeKey=EventSource,AttributeValue=lambda.amazonaws.com --start-time YYYY-MM-DDTHH:MM:SS+00:00 --end-time YYYY-MM-DDTHH:MM:SS+00:00 | grep -i EventName | grep -v CloudTrailEvent | sort | uniq -c | sort -r

--- a/aws-cli-lambda-rate-exceeded-source/snippet-users.txt
+++ b/aws-cli-lambda-rate-exceeded-source/snippet-users.txt
@@ -1,0 +1,1 @@
+aws cloudtrail lookup-events --lookup-attributes AttributeKey=EventSource,AttributeValue=lambda.amazonaws.com --start-time YYYY-MM-DDTHH:MM:SS+00:00 --end-time YYYY-MM-DDTHH:MM:SS+00:00 | grep -i Username | grep -v CloudTrailEvent | sort | uniq -c | sort -r

--- a/lambda-disable-recursion-protection/README.md
+++ b/lambda-disable-recursion-protection/README.md
@@ -1,0 +1,10 @@
+<div align="center">
+
+<h1>Explore <a href="https://serverlessland.com">ServerlessLand</a></h1>
+
+
+![ServerlessLand.com](../serverlessland.png)
+[Explore 700+ patterns](https://serverlessland.com/patterns?ref=github-snippets) | [Explore 50+ guides](https://serverlessland.com/learn?ref=github-snippets) | [Explore 80+ guides](https://serverlessland.com/snippets?ref=github-snippets)
+
+</div>
+

--- a/lambda-disable-recursion-protection/snippet-data.json
+++ b/lambda-disable-recursion-protection/snippet-data.json
@@ -1,0 +1,36 @@
+{
+  "title": "Disabling Function Code Recursion Protection",
+  "description": "Configures a Lambda function to automatically terminate recursive invocation loops, preventing infinite call chains and runaway costs.",
+  "type": "Integration",
+  "services": ["lambda"],
+  "tags": ["lambda"],
+  "languages": ["AWS Cli"],
+  "introBox": {
+    "headline": "How it works",
+    "text": [
+      "AWS Lambda features built-in recursion detection for loops between Lambda and Amazon SQS or AWS DynamoDB. If your architecture relies on intentional multi-cycle patterns, this guardrail will loop-terminate your function automatically. To turn this safeguard off, you can override it directly via the CLI:"
+    ]
+  },
+  "gitHub": {
+    "template": {
+      "repoURL": "https://github.com/aws-samples/serverless-snippets/tree/main/lambda-disable-recursion-protection"
+    }
+  },
+  "snippets": [
+    {
+      "title": ["Lambda can detect certain types of recursive loops shortly after they occur. When Lambda detects a recursive loop and your function’s recursive loop detection configuration is set to Terminate , it stops your function being invoked and notifies you.",
+               "The possible values are 'Allow' & 'Terminate'. When this value is set to 'Allow' and Lambda detects your function being invoked as part of a recursive loop, it doesn’t take any action. When this value is set to 'Terminate' and Lambda detects your function being invoked as part of a recursive loop, it stops your function being invoked and notifies you."],
+      "snippetPath": "snippet.txt",
+      "language": "cli" 
+    }
+  ],
+  "authors": [
+    {
+      "headline": "Presented by Annangarachari R",
+      "name": "Annangarachari R",
+      "image": "https://media.licdn.com/dms/image/v2/D5603AQGJ4TjBa44wFg/profile-displayphoto-scale_400_400/B56Z5Y28nWGgAo-/0/1779607260719?e=1781136000&v=beta&t=pou5fuFAMTmw7PuyTc2Jli6aYkWqnLhqHgzw-Bn9pDI",
+      "bio": "Serverless Enthusiast",
+      "linkedin": "https://www.linkedin.com/in/annangarachari-r/"
+    }
+  ]
+}

--- a/lambda-disable-recursion-protection/snippet.txt
+++ b/lambda-disable-recursion-protection/snippet.txt
@@ -1,0 +1,3 @@
+aws lambda put-function-recursion-config \
+    --function-name <your-function-name> \
+    --recursive-loop Terminate


### PR DESCRIPTION
*Description of changes:*
AWS Lambda features built-in recursion detection for loops between Lambda and Amazon SQS or AWS DynamoDB. If your architecture relies on intentional multi-cycle patterns, this guardrail will loop-terminate your function automatically. To turn this safeguard off, you can override it directly via the CLI.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
